### PR TITLE
Add proxy support for HTTPS_PROXY/https_proxy environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "keytar": "^7.9.0",
         "ora": "^9.0.0",
         "proper-lockfile": "^4.1.2",
+        "undici": "^7.19.2",
         "uuid": "^13.0.0"
       },
       "bin": {
@@ -11127,10 +11128,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
-      "dev": true,
+      "version": "7.19.2",
+      "resolved": "https://npm.artifacts.indeed.tech/npm/undici/-/undici-7.19.2.tgz",
+      "integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "keytar": "^7.9.0",
     "ora": "^9.0.0",
     "proper-lockfile": "^4.1.2",
+    "undici": "^7.19.2",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -127,7 +127,7 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     if (options.mcpSessionId) {
       transportOptions.mcpSessionId = options.mcpSessionId;
     }
-    const transport = createTransportFromConfig(options.serverConfig, transportOptions);
+    const transport = await createTransportFromConfig(options.serverConfig, transportOptions);
     await client.connect(transport);
   }
 

--- a/test/unit/core/factory.test.ts
+++ b/test/unit/core/factory.test.ts
@@ -5,9 +5,9 @@
 import { McpClient } from '../../../src/core/mcp-client.js';
 import { createMcpClient } from '../../../src/core/factory.js';
 
-// Mock the transports
+// Mock the transports (now async)
 jest.mock('../../../src/core/transports', () => ({
-  createTransportFromConfig: jest.fn().mockReturnValue({
+  createTransportFromConfig: jest.fn().mockResolvedValue({
     start: jest.fn().mockResolvedValue(undefined),
     send: jest.fn().mockResolvedValue(undefined),
     close: jest.fn().mockResolvedValue(undefined),

--- a/test/unit/core/transports.test.ts
+++ b/test/unit/core/transports.test.ts
@@ -4,6 +4,7 @@
 
 import { createTransportFromConfig } from '../../../src/core/transports';
 import { ClientError } from '../../../src/lib/errors';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 // Mock the SDK transports
 jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
@@ -24,9 +25,29 @@ jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
   StreamableHTTPError: class StreamableHTTPError extends Error {},
 }));
 
+// Mock undici for proxy tests
+jest.mock('undici', () => ({
+  ProxyAgent: jest.fn().mockImplementation((url: string) => ({ proxyUrl: url })),
+  fetch: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
 describe('createTransportFromConfig', () => {
-  it('should create stdio transport from config', () => {
-    const transport = createTransportFromConfig({
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset environment variables before each test
+    process.env = { ...originalEnv };
+    delete process.env.https_proxy;
+    delete process.env.HTTPS_PROXY;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should create stdio transport from config', async () => {
+    const transport = await createTransportFromConfig({
       command: 'node',
       args: ['server.js'],
     });
@@ -34,22 +55,22 @@ describe('createTransportFromConfig', () => {
     expect(transport).toBeDefined();
   });
 
-  it('should create http transport from config', () => {
-    const transport = createTransportFromConfig({
+  it('should create http transport from config', async () => {
+    const transport = await createTransportFromConfig({
       url: 'https://mcp.example.com',
     });
 
     expect(transport).toBeDefined();
   });
 
-  it('should throw error for config without url or command', () => {
-    expect(() =>
+  it('should throw error for config without url or command', async () => {
+    await expect(
       createTransportFromConfig({} as any)
-    ).toThrow(ClientError);
+    ).rejects.toThrow(ClientError);
   });
 
-  it('should pass headers to http transport', () => {
-    const transport = createTransportFromConfig({
+  it('should pass headers to http transport', async () => {
+    const transport = await createTransportFromConfig({
       url: 'https://mcp.example.com',
       headers: {
         Authorization: 'Bearer token',
@@ -59,8 +80,8 @@ describe('createTransportFromConfig', () => {
     expect(transport).toBeDefined();
   });
 
-  it('should pass environment variables to stdio transport', () => {
-    const transport = createTransportFromConfig({
+  it('should pass environment variables to stdio transport', async () => {
+    const transport = await createTransportFromConfig({
       command: 'node',
       args: ['server.js'],
       env: {
@@ -69,5 +90,89 @@ describe('createTransportFromConfig', () => {
     });
 
     expect(transport).toBeDefined();
+  });
+});
+
+describe('proxy-aware fetch', () => {
+  const originalEnv = process.env;
+  const MockedStreamableHTTPClientTransport = StreamableHTTPClientTransport as jest.MockedClass<typeof StreamableHTTPClientTransport>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.https_proxy;
+    delete process.env.HTTPS_PROXY;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should not use proxy fetch when no proxy env var is set', async () => {
+    await createTransportFromConfig({
+      url: 'https://mcp.example.com',
+    });
+
+    // Check that StreamableHTTPClientTransport was called without a custom fetch
+    expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+    const callArgs = MockedStreamableHTTPClientTransport.mock.calls[0];
+    expect(callArgs[1]).not.toHaveProperty('fetch');
+  });
+
+  it('should use proxy fetch when https_proxy is set', async () => {
+    process.env.https_proxy = 'http://localhost:8080';
+
+    await createTransportFromConfig({
+      url: 'https://mcp.example.com',
+    });
+
+    // Check that StreamableHTTPClientTransport was called with a custom fetch
+    expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+    const callArgs = MockedStreamableHTTPClientTransport.mock.calls[0];
+    expect(callArgs[1]).toHaveProperty('fetch');
+    expect(typeof callArgs[1]?.fetch).toBe('function');
+  });
+
+  it('should use proxy fetch when HTTPS_PROXY is set', async () => {
+    process.env.HTTPS_PROXY = 'http://localhost:8080';
+
+    await createTransportFromConfig({
+      url: 'https://mcp.example.com',
+    });
+
+    // Check that StreamableHTTPClientTransport was called with a custom fetch
+    expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+    const callArgs = MockedStreamableHTTPClientTransport.mock.calls[0];
+    expect(callArgs[1]).toHaveProperty('fetch');
+    expect(typeof callArgs[1]?.fetch).toBe('function');
+  });
+
+  it('should prefer https_proxy over HTTPS_PROXY when both are set', async () => {
+    process.env.https_proxy = 'http://localhost:8080';
+    process.env.HTTPS_PROXY = 'http://localhost:9090';
+
+    await createTransportFromConfig({
+      url: 'https://mcp.example.com',
+    });
+
+    // The proxy fetch should be configured (we can't easily verify which URL was used
+    // without more complex mocking, but we can verify a fetch was provided)
+    expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+    const callArgs = MockedStreamableHTTPClientTransport.mock.calls[0];
+    expect(callArgs[1]).toHaveProperty('fetch');
+  });
+
+  it('should not affect stdio transport when proxy is set', async () => {
+    process.env.https_proxy = 'http://localhost:8080';
+
+    const transport = await createTransportFromConfig({
+      command: 'node',
+      args: ['server.js'],
+    });
+
+    // Stdio transport should still work normally
+    expect(transport).toBeDefined();
+    // StreamableHTTPClientTransport should not have been called
+    expect(MockedStreamableHTTPClientTransport).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds proxy support for environments that route network traffic through HTTP proxies (e.g., Claude Code sandbox)
- Detects `https_proxy` / `HTTPS_PROXY` environment variables and creates a proxy-aware fetch using undici's `ProxyAgent`
- All existing tests pass, plus 5 new tests for proxy functionality

## Problem

Node.js native `fetch()` (powered by undici) does not respect proxy environment variables. This causes mcpc to fail with `getaddrinfo ENOTFOUND` errors in environments like Claude Code's sandbox, which routes all network traffic through a local HTTP proxy.

## Solution

When proxy environment variables are detected, create a custom fetch function using undici's `ProxyAgent` and pass it to the MCP SDK's `StreamableHTTPClientTransport`:

```typescript
const { ProxyAgent, fetch: undiciFetch } = await import('undici');
const proxyAgent = new ProxyAgent(proxyUrl);

const proxyFetch = (input, init) => {
  return undiciFetch(input, { ...init, dispatcher: proxyAgent });
};
```

## Changes

| File | Description |
|------|-------------|
| `package.json` | Added `undici` dependency |
| `src/core/transports.ts` | Added `createProxyAwareFetch()`, made transport functions async |
| `src/core/factory.ts` | Added `await` for async transport creation |
| `test/unit/core/transports.test.ts` | Added 5 proxy tests, updated existing tests |
| `test/unit/core/factory.test.ts` | Updated mock to return Promise |

## Test plan

- [x] All 340 existing unit tests pass
- [x] 5 new proxy-aware fetch tests pass
- [x] Manually verified: mcpc successfully connects to remote MCP servers through Claude Code's sandbox proxy

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)