### PR TITLE
Replace keytar with @napi-rs/keyring for OS keychain access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@inquirer/input": "^5.0.3",
         "@inquirer/select": "^5.0.3",
         "@modelcontextprotocol/sdk": "^1.25.1",
+        "@napi-rs/keyring": "^1.2.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
-        "keytar": "^7.9.0",
         "ora": "^9.0.0",
         "proper-lockfile": "^4.1.2",
         "uuid": "^13.0.0"
@@ -1580,6 +1580,225 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2616,26 +2835,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.5.tgz",
@@ -2654,17 +2853,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -2776,30 +2964,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -3282,12 +3446,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -3750,21 +3908,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -3778,15 +3921,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3880,15 +4014,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -4089,15 +4214,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -4607,15 +4723,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
@@ -4993,12 +5100,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5195,12 +5296,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -5569,26 +5664,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5672,12 +5747,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -7359,17 +7428,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/keytar": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
-      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.0.1"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7994,18 +8052,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -8026,6 +8072,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8041,12 +8088,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8061,12 +8102,6 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -8146,24 +8181,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "license": "MIT"
     },
     "node_modules/node-email-verifier": {
       "version": "3.4.1",
@@ -9146,32 +9163,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9310,16 +9301,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9407,50 +9388,12 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9823,26 +9766,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9895,6 +9818,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10101,51 +10025,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10339,15 +10218,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -10611,34 +10481,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -10898,18 +10740,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -11293,12 +11123,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "@inquirer/input": "^5.0.3",
     "@inquirer/select": "^5.0.3",
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "@napi-rs/keyring": "^1.2.0",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",
-    "keytar": "^7.9.0",
     "ora": "^9.0.0",
     "proper-lockfile": "^4.1.2",
     "uuid": "^13.0.0"

--- a/src/lib/auth/keychain.ts
+++ b/src/lib/auth/keychain.ts
@@ -1,119 +1,140 @@
 /**
  * OS Keychain integration for secure credential storage
- * Uses keytar package for cross-platform keychain access
+ * Uses @napi-rs/keyring package for cross-platform keychain access
  */
 
-import keytar from 'keytar';
-import { createLogger } from '../logger.js';
-import { getServerHost } from '../utils.js';
+import { Entry } from "@napi-rs/keyring";
+import { createLogger } from "../logger.js";
+import { getServerHost } from "../utils.js";
 
-const logger = createLogger('keychain');
+const logger = createLogger("keychain");
 
 // Service name for all mcpc credentials in the keychain
-const SERVICE_NAME = 'mcpc';
+const SERVICE_NAME = "mcpc";
 
 /**
  * OAuth client information (from dynamic registration)
  */
 export interface OAuthClientInfo {
-  clientId: string;
-  clientSecret?: string;
+	clientId: string;
+	clientSecret?: string;
 }
 
 /**
  * OAuth tokens
  */
 export interface OAuthTokenInfo {
-  accessToken: string;
-  refreshToken?: string;
-  tokenType: string;
-  expiresIn?: number;
-  expiresAt?: number; // Unix timestamp
-  scope?: string;
+	accessToken: string;
+	refreshToken?: string;
+	tokenType: string;
+	expiresIn?: number;
+	expiresAt?: number; // Unix timestamp
+	scope?: string;
 }
 
 /**
  * Get a keychain account name for OAuth client info
  * Uses getServerHost() to normalize the server URL to a canonical host
  */
-function buildOAuthClientAccountName(serverUrl: string, profileName: string): string {
-  const host = getServerHost(serverUrl);
-  return `auth-profile:${host}:${profileName}:client`;
+function buildOAuthClientAccountName(
+	serverUrl: string,
+	profileName: string,
+): string {
+	const host = getServerHost(serverUrl);
+	return `auth-profile:${host}:${profileName}:client`;
 }
 
 /**
  * Get a keychain account name for OAuth tokens
  * Uses getServerHost() to normalize the server URL to a canonical host
  */
-function buildOAuthTokensAccountName(serverUrl: string, profileName: string): string {
-  const host = getServerHost(serverUrl);
-  return `auth-profile:${host}:${profileName}:tokens`;
+function buildOAuthTokensAccountName(
+	serverUrl: string,
+	profileName: string,
+): string {
+	const host = getServerHost(serverUrl);
+	return `auth-profile:${host}:${profileName}:tokens`;
 }
 
 /**
  * Get a keychain account name for session headers
  */
 function buildSessionAccountName(sessionName: string): string {
-  return `session:${sessionName}:headers`;
+	return `session:${sessionName}:headers`;
 }
 
 /**
  * Get a keychain account name for proxy bearer token
  */
 function buildProxyBearerTokenAccountName(sessionName: string): string {
-  return `session:${sessionName}:proxy-bearer-token`;
+	return `session:${sessionName}:proxy-bearer-token`;
 }
 
 /**
  * Store OAuth client info in keychain
  */
 export async function storeKeychainOAuthClientInfo(
-  serverUrl: string,
-  profileName: string,
-  client: OAuthClientInfo
+	serverUrl: string,
+	profileName: string,
+	client: OAuthClientInfo,
 ): Promise<void> {
-  const account = buildOAuthClientAccountName(serverUrl, profileName);
-  const value = JSON.stringify(client);
+	const account = buildOAuthClientAccountName(serverUrl, profileName);
+	const value = JSON.stringify(client);
 
-  logger.debug(`Storing OAuth client info for ${profileName} @ ${serverUrl}`);
-  await keytar.setPassword(SERVICE_NAME, account, value);
+	logger.debug(`Storing OAuth client info for ${profileName} @ ${serverUrl}`);
+	new Entry(SERVICE_NAME, account).setPassword(value);
 }
 
 /**
  * Get OAuth client info from keychain
  */
 export async function readKeychainOAuthClientInfo(
-  serverUrl: string,
-  profileName: string
+	serverUrl: string,
+	profileName: string,
 ): Promise<OAuthClientInfo | undefined> {
-  const account = buildOAuthClientAccountName(serverUrl, profileName);
+	const account = buildOAuthClientAccountName(serverUrl, profileName);
 
-  logger.debug(`Retrieving OAuth client info for ${profileName} @ ${serverUrl}`);
-  const value = await keytar.getPassword(SERVICE_NAME, account);
+	logger.debug(
+		`Retrieving OAuth client info for ${profileName} @ ${serverUrl}`,
+	);
 
-  if (!value) {
-    return undefined;
-  }
+	let value: string | null;
+	try {
+		value = new Entry(SERVICE_NAME, account).getPassword();
+	} catch {
+		return undefined;
+	}
 
-  try {
-    return JSON.parse(value) as OAuthClientInfo;
-  } catch (error) {
-    logger.error(`Failed to parse OAuth client info from keychain: ${(error as Error).message}`);
-    return undefined;
-  }
+	if (!value) {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(value) as OAuthClientInfo;
+	} catch (error) {
+		logger.error(
+			`Failed to parse OAuth client info from keychain: ${(error as Error).message}`,
+		);
+		return undefined;
+	}
 }
 
 /**
  * Delete OAuth client info from keychain
  */
 export async function removeKeychainOAuthClientInfo(
-  serverUrl: string,
-  profileName: string
+	serverUrl: string,
+	profileName: string,
 ): Promise<boolean> {
-  const account = buildOAuthClientAccountName(serverUrl, profileName);
+	const account = buildOAuthClientAccountName(serverUrl, profileName);
 
-  logger.debug(`Deleting OAuth client info for ${profileName} @ ${serverUrl}`);
-  return keytar.deletePassword(SERVICE_NAME, account);
+	logger.debug(`Deleting OAuth client info for ${profileName} @ ${serverUrl}`);
+	try {
+		new Entry(SERVICE_NAME, account).deletePassword();
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -121,52 +142,65 @@ export async function removeKeychainOAuthClientInfo(
  * TODO: The operations on Keychain should be done under profiles file lock, to ensure atomocity...
  */
 export async function storeKeychainOAuthTokenInfo(
-  serverUrl: string,
-  profileName: string,
-  tokens: OAuthTokenInfo
+	serverUrl: string,
+	profileName: string,
+	tokens: OAuthTokenInfo,
 ): Promise<void> {
-  const account = buildOAuthTokensAccountName(serverUrl, profileName);
-  const value = JSON.stringify(tokens);
+	const account = buildOAuthTokensAccountName(serverUrl, profileName);
+	const value = JSON.stringify(tokens);
 
-  logger.debug(`Storing OAuth tokens for ${profileName} @ ${serverUrl}`);
-  await keytar.setPassword(SERVICE_NAME, account, value);
+	logger.debug(`Storing OAuth tokens for ${profileName} @ ${serverUrl}`);
+	new Entry(SERVICE_NAME, account).setPassword(value);
 }
 
 /**
  * Get OAuth tokens from keychain
  */
 export async function readKeychainOAuthTokenInfo(
-  serverUrl: string,
-  profileName: string
+	serverUrl: string,
+	profileName: string,
 ): Promise<OAuthTokenInfo | undefined> {
-  const account = buildOAuthTokensAccountName(serverUrl, profileName);
+	const account = buildOAuthTokensAccountName(serverUrl, profileName);
 
-  logger.debug(`Retrieving OAuth tokens for ${profileName} @ ${serverUrl}`);
-  const value = await keytar.getPassword(SERVICE_NAME, account);
+	logger.debug(`Retrieving OAuth tokens for ${profileName} @ ${serverUrl}`);
 
-  if (!value) {
-    return undefined;
-  }
+	let value: string | null;
+	try {
+		value = new Entry(SERVICE_NAME, account).getPassword();
+	} catch {
+		return undefined;
+	}
 
-  try {
-    return JSON.parse(value) as OAuthTokenInfo;
-  } catch (error) {
-    logger.error(`Failed to parse OAuth tokens from keychain: ${(error as Error).message}`);
-    return undefined;
-  }
+	if (!value) {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(value) as OAuthTokenInfo;
+	} catch (error) {
+		logger.error(
+			`Failed to parse OAuth tokens from keychain: ${(error as Error).message}`,
+		);
+		return undefined;
+	}
 }
 
 /**
  * Delete OAuth tokens from keychain
  */
 export async function removeKeychainOAuthTokenInfo(
-  serverUrl: string,
-  profileName: string
+	serverUrl: string,
+	profileName: string,
 ): Promise<boolean> {
-  const account = buildOAuthTokensAccountName(serverUrl, profileName);
+	const account = buildOAuthTokensAccountName(serverUrl, profileName);
 
-  logger.debug(`Deleting OAuth tokens for ${profileName} @ ${serverUrl}`);
-  return keytar.deletePassword(SERVICE_NAME, account);
+	logger.debug(`Deleting OAuth tokens for ${profileName} @ ${serverUrl}`);
+	try {
+		new Entry(SERVICE_NAME, account).deletePassword();
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -174,47 +208,62 @@ export async function removeKeychainOAuthTokenInfo(
  * All headers from --header flags are treated as potentially sensitive
  */
 export async function storeKeychainSessionHeaders(
-  sessionName: string,
-  headers: Record<string, string>
+	sessionName: string,
+	headers: Record<string, string>,
 ): Promise<void> {
-  const account = buildSessionAccountName(sessionName);
-  const value = JSON.stringify(headers);
+	const account = buildSessionAccountName(sessionName);
+	const value = JSON.stringify(headers);
 
-  logger.debug(`Storing headers for session ${sessionName}`);
-  await keytar.setPassword(SERVICE_NAME, account, value);
+	logger.debug(`Storing headers for session ${sessionName}`);
+	new Entry(SERVICE_NAME, account).setPassword(value);
 }
 
 /**
  * Retrieve HTTP headers for a session from keychain
  */
 export async function readKeychainSessionHeaders(
-  sessionName: string
+	sessionName: string,
 ): Promise<Record<string, string> | undefined> {
-  const account = buildSessionAccountName(sessionName);
+	const account = buildSessionAccountName(sessionName);
 
-  logger.debug(`Retrieving headers for session ${sessionName}`);
-  const value = await keytar.getPassword(SERVICE_NAME, account);
+	logger.debug(`Retrieving headers for session ${sessionName}`);
 
-  if (!value) {
-    return undefined;
-  }
+	let value: string | null;
+	try {
+		value = new Entry(SERVICE_NAME, account).getPassword();
+	} catch {
+		return undefined;
+	}
 
-  try {
-    return JSON.parse(value) as Record<string, string>;
-  } catch (error) {
-    logger.error(`Failed to parse headers from keychain: ${(error as Error).message}`);
-    return undefined;
-  }
+	if (!value) {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(value) as Record<string, string>;
+	} catch (error) {
+		logger.error(
+			`Failed to parse headers from keychain: ${(error as Error).message}`,
+		);
+		return undefined;
+	}
 }
 
 /**
  * Delete HTTP headers for a session from keychain
  */
-export async function removeKeychainSessionHeaders(sessionName: string): Promise<boolean> {
-  const account = buildSessionAccountName(sessionName);
+export async function removeKeychainSessionHeaders(
+	sessionName: string,
+): Promise<boolean> {
+	const account = buildSessionAccountName(sessionName);
 
-  logger.debug(`Deleting headers for session ${sessionName}`);
-  return keytar.deletePassword(SERVICE_NAME, account);
+	logger.debug(`Deleting headers for session ${sessionName}`);
+	try {
+		new Entry(SERVICE_NAME, account).deletePassword();
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -222,33 +271,44 @@ export async function removeKeychainSessionHeaders(sessionName: string): Promise
  * Used to secure the proxy MCP server with authentication
  */
 export async function storeKeychainProxyBearerToken(
-  sessionName: string,
-  token: string
+	sessionName: string,
+	token: string,
 ): Promise<void> {
-  const account = buildProxyBearerTokenAccountName(sessionName);
+	const account = buildProxyBearerTokenAccountName(sessionName);
 
-  logger.debug(`Storing proxy bearer token for session ${sessionName}`);
-  await keytar.setPassword(SERVICE_NAME, account, token);
+	logger.debug(`Storing proxy bearer token for session ${sessionName}`);
+	new Entry(SERVICE_NAME, account).setPassword(token);
 }
 
 /**
  * Retrieve proxy bearer token for a session from keychain
  */
 export async function readKeychainProxyBearerToken(
-  sessionName: string
+	sessionName: string,
 ): Promise<string | undefined> {
-  const account = buildProxyBearerTokenAccountName(sessionName);
+	const account = buildProxyBearerTokenAccountName(sessionName);
 
-  logger.debug(`Retrieving proxy bearer token for session ${sessionName}`);
-  return (await keytar.getPassword(SERVICE_NAME, account)) || undefined;
+	logger.debug(`Retrieving proxy bearer token for session ${sessionName}`);
+	try {
+		return new Entry(SERVICE_NAME, account).getPassword() || undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 /**
  * Delete proxy bearer token for a session from keychain
  */
-export async function removeKeychainProxyBearerToken(sessionName: string): Promise<boolean> {
-  const account = buildProxyBearerTokenAccountName(sessionName);
+export async function removeKeychainProxyBearerToken(
+	sessionName: string,
+): Promise<boolean> {
+	const account = buildProxyBearerTokenAccountName(sessionName);
 
-  logger.debug(`Deleting proxy bearer token for session ${sessionName}`);
-  return keytar.deletePassword(SERVICE_NAME, account);
+	logger.debug(`Deleting proxy bearer token for session ${sessionName}`);
+	try {
+		new Entry(SERVICE_NAME, account).deletePassword();
+		return true;
+	} catch {
+		return false;
+	}
 }


### PR DESCRIPTION
## Summary

- Replaces deprecated `keytar` package with `@napi-rs/keyring` for OS keychain access
- `keytar` has persistent native module build issues across platforms; `@napi-rs/keyring` ships prebuilt binaries via napi-rs and is actively maintained
- All keychain operations (store/read/delete for OAuth client info, tokens, session headers, proxy bearer tokens) are migrated to the new API

## Changes

- `src/lib/auth/keychain.ts` — migrated from `keytar` async API (`keytar.setPassword/getPassword/deletePassword`) to `@napi-rs/keyring` sync API (`new Entry(service, account).setPassword/getPassword/deletePassword`)
- `package.json` — replaced `keytar: ^7.9.0` with `@napi-rs/keyring: ^1.2.0`

## Test plan

- [x] `npm run build` passes
- [x] `npm test` (unit + E2E) passes
- [x] Manual verification of `@napi-rs/keyring` API: setPassword, getPassword, deletePassword all work correctly on macOS
- [ ] Verify OAuth login/logout flow with a real MCP server
- [ ] Verify on Linux (may need `libsecret` like keytar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)