### PR TITLE
fix: avoid EXDEV error when writing temp files on Linux

### DIFF
--- a/src/lib/auth/profiles.ts
+++ b/src/lib/auth/profiles.ts
@@ -5,7 +5,6 @@
  */
 
 import { readFile, writeFile, rename, unlink } from 'fs/promises';
-import { tmpdir } from 'os';
 import { join } from 'path';
 import type { AuthProfile, AuthProfilesStorage } from '../types.js';
 import {
@@ -64,7 +63,9 @@ async function saveAuthProfilesInternal(storage: AuthProfilesStorage): Promise<v
   await ensureDir(getMcpcHome());
 
   // Write to a temp file first (atomic operation)
-  const tempFile = join(tmpdir(), `mcpc-auth-profiles-${Date.now()}-${process.pid}.json`);
+  // Write temp file in the same directory as the target to avoid EXDEV on Linux
+  // (rename() fails across filesystem boundaries, e.g. /tmp vs ~/.mcpc)
+  const tempFile = join(getMcpcHome(), `.profiles-${Date.now()}-${process.pid}.tmp`);
 
   try {
     const content = JSON.stringify(storage, null, 2);

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -5,7 +5,6 @@
  */
 
 import { readFile, writeFile, rename, unlink } from 'fs/promises';
-import { tmpdir } from 'os';
 import { join } from 'path';
 import type { SessionData, SessionsStorage } from './types.js';
 import {
@@ -62,7 +61,9 @@ async function saveSessionsInternal(storage: SessionsStorage): Promise<void> {
   await ensureDir(getMcpcHome());
 
   // Write to a temp file first (atomic operation)
-  const tempFile = join(tmpdir(), `mcpc-sessions-${Date.now()}-${process.pid}.json`);
+  // Write temp file in the same directory as the target to avoid EXDEV on Linux
+  // (rename() fails across filesystem boundaries, e.g. /tmp vs ~/.mcpc)
+  const tempFile = join(getMcpcHome(), `.sessions-${Date.now()}-${process.pid}.tmp`);
 
   try {
     const content = JSON.stringify(storage, null, 2);


### PR DESCRIPTION
## Summary

- Fix `EXDEV: cross-device link not permitted` error on Linux systems where `/tmp` is a separate `tmpfs` filesystem
- Write temp files to `~/.mcpc/` (same directory as the target) instead of `/tmp`, so `rename()` never crosses filesystem boundaries
- Affects `sessions.ts` and `profiles.ts` (atomic write pattern for `sessions.json` and `profiles.json`)

## Problem

On many Linux systems, `/tmp` is mounted as `tmpfs` (RAM-backed), which is a different filesystem from the user's home directory. The atomic write pattern (write to temp file → `rename()` to target) relies on `rename()` being atomic, but `rename()` fails with `EXDEV` when source and destination are on different filesystems.

## Fix

Use a dot-prefixed temp file in `~/.mcpc/` (e.g. `.sessions-<timestamp>-<pid>.tmp`) instead of `/tmp`. Since source and target are now on the same filesystem, `rename()` works correctly and remains atomic.