### PR TITLE
feat: x402 payment protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ After all, UNIX-compatible shell script is THE most universal coding language.
 ![mcpc screenshot](https://raw.githubusercontent.com/apify/mcpc/main/docs/images/mcpc-demo.gif)
 
 **Key features:**
+
 - 🌎 **Compatible** - Works with any MCP server over Streamable HTTP or stdio.
 - 🔄 **Persistent sessions** - Keep multiple server connections alive simultaneously.
 - 🔧 **Strong MCP support** - Instructions, tools, resources, prompts, dynamic discovery.
@@ -17,7 +18,7 @@ After all, UNIX-compatible shell script is THE most universal coding language.
 - 🤖 **AI sandboxing** - MCP proxy server to securely access authenticated sessions from AI-generated code.
 - 🔒 **Secure** - Full OAuth 2.1 support, OS keychain for credentials storage.
 - 🪶 **Lightweight** - Minimal dependencies, works on Mac/Win/Linux, doesn't use LLMs on its own.
-
+- 💸 **[Agentic payments (x402)](#agentic-payments-x402)** - Experimental support for the [x402](https://www.x402.org/) payment protocol, enabling AI agents to pay for MCP tool calls with USDC on Base.
 
 ## Table of contents
 
@@ -31,6 +32,7 @@ After all, UNIX-compatible shell script is THE most universal coding language.
 - [Authentication](#authentication)
 - [MCP proxy](#mcp-proxy)
 - [AI agents](#ai-agents)
+- [Agentic payments (x402)](#agentic-payments-x402)
 - [MCP support](#mcp-support)
 - [Configuration](#configuration)
 - [Security](#security)
@@ -117,6 +119,7 @@ Options:
   --timeout <seconds>           Request timeout in seconds (default: 300)
   --proxy <[host:]port>         Start proxy MCP server for session (with "connect" command)
   --proxy-bearer-token <token>  Require authentication for access to proxy server
+  --x402                        Enable x402 auto-payment using the configured wallet
   --clean[=types]               Clean up mcpc data (types: sessions, logs, profiles, all)
   -h, --help                    Display general help
 
@@ -148,7 +151,14 @@ MCP server commands:
   resources-templates-list
   logging-set-level <level>
   ping
-  
+
+x402 payment commands (no target needed):
+  x402 init                     Create a new x402 wallet
+  x402 import <key>             Import wallet from private key
+  x402 info                     Show wallet info
+  x402 sign -r <base64>         Sign payment from PAYMENT-REQUIRED header
+  x402 remove                   Remove the wallet
+
 Run "mcpc" without <target> to show available sessions and profiles.
 ```
 
@@ -181,6 +191,7 @@ To connect and interact with an MCP server, you need to specify a `<target>`, wh
 connects, and enables you to interact with it.
 
 **URL handling:**
+
 - URLs without a scheme (e.g. `mcp.apify.com`) default to `https://`
 - `localhost` and `127.0.0.1` addresses without a scheme default to `http://` (for local dev/proxy servers)
 - To override the default, specify the scheme explicitly (e.g. `http://example.com`)
@@ -229,6 +240,7 @@ cat args.json | mcpc <target> tools-call <tool-name>
 ```
 
 **Rules:**
+
 - All arguments use `:=` syntax: `key:=value`
 - Values are auto-parsed: valid JSON becomes that type, otherwise treated as string
   - `count:=10` → number `10`
@@ -257,6 +269,7 @@ echo "{\"query\": \"${QUERY}\", \"limit\": 10}" | mcpc @server tools-call search
 ```
 
 **Common pitfall:** Don't put spaces around `:=` - it won't work:
+
 ```bash
 # Wrong - spaces around :=
 mcpc @server tools-call search query := "hello world"
@@ -329,7 +342,7 @@ Still, sessions can fail due to network disconnects, bridge process crash, or se
 **Session states:**
 
 | State            | Meaning                                                                                       |
-|------------------|-----------------------------------------------------------------------------------------------|
+| ---------------- | --------------------------------------------------------------------------------------------- |
 | 🟢 **`live`**    | Bridge process is running; server might or might not be operational                           |
 | 🟡 **`crashed`** | Bridge process crashed or was killed; will auto-restart on next use                           |
 | 🔴 **`expired`** | Server rejected the session (auth failed, session ID invalid); requires `close` and reconnect |
@@ -364,7 +377,6 @@ and opens new connection with new `MCP-Session-Id`, by running:
 ```bash
 mcpc @apify restart
 ```
-
 
 ## Authentication
 
@@ -404,8 +416,8 @@ mcpc @apify tools-list
 
 ### OAuth profiles
 
-For OAuth-enabled remote MCP servers, `mcpc` implements the full OAuth 2.1 flow with PKCE, 
-including `WWW-Authenticate` header discovery, server metadata discovery, client ID metadata documents, 
+For OAuth-enabled remote MCP servers, `mcpc` implements the full OAuth 2.1 flow with PKCE,
+including `WWW-Authenticate` header discovery, server metadata discovery, client ID metadata documents,
 dynamic client registration, and automatic token refresh.
 
 The OAuth authentication **always** needs to be initiated by the user calling the `login` command,
@@ -413,11 +425,13 @@ which opens a web browser with login screen. `mcpc` never opens the web browser 
 
 The OAuth credentials to specific servers are securely stored as **authentication profiles** - reusable
 credentials that allow you to:
+
 - Authenticate once, use credentials across multiple commands or sessions
 - Use different accounts (profiles) with the same server
 - Manage credentials independently from sessions
 
 Key concepts:
+
 - **Authentication profile**: Named set of OAuth credentials for a specific server (stored in `~/.mcpc/profiles.json` + OS keychain)
 - **Session**: Active connection to a server that may reference an authentication profile (stored in `~/.mcpc/sessions.json`)
 - **Default profile**: When `--profile` is not specified, `mcpc` uses the authentication profile named `default`
@@ -456,7 +470,6 @@ When multiple authentication methods are available, `mcpc` uses this precedence 
 3. **Config file headers** - Headers from `--config` file for the server
 4. **No authentication** - Attempts unauthenticated connection
 
-
 `mcpc` automatically handles authentication based on whether you specify a profile:
 
 **When `--profile <name>` is specified:**
@@ -478,6 +491,7 @@ When multiple authentication methods are available, `mcpc` uses this precedence 
 On failure, the error message includes instructions on how to login and save the profile, so you know what to do.
 
 This flow ensures:
+
 - You only authenticate when necessary
 - Credentials are never silently mixed up (personal → work) or downgraded (authenticated → unauthenticated)
 - You can mix authenticated sessions (with named profiles) and public access on the same server
@@ -499,7 +513,6 @@ mcpc mcp.apify.com connect @apify-personal
 # Public server - no authentication needed:
 mcpc mcp.apify.com\?tools=docs tools-list
 ```
-
 
 ## MCP proxy
 
@@ -534,7 +547,7 @@ mcpc localhost:8081 connect @sandboxed2 --header "Authorization: Bearer secret12
 **Proxy options for `connect` command:**
 
 | Option                         | Description                                                                    |
-|--------------------------------|--------------------------------------------------------------------------------|
+| ------------------------------ | ------------------------------------------------------------------------------ |
 | `--proxy [host:]port`          | Start proxy MCP server. Default host: `127.0.0.1` (localhost only)             |
 | `--proxy-bearer-token <token>` | Requires `Authorization: Bearer <token>` header to access the proxy MCP server |
 
@@ -564,7 +577,6 @@ When listing sessions, proxy info is displayed prominently:
 mcpc
 # @relay → https://mcp.apify.com (HTTP, OAuth: default) [proxy: 127.0.0.1:8080]
 ```
-
 
 ## AI agents
 
@@ -635,6 +647,7 @@ mcpc @apify tools-call search-actors --schema expected.json keywords:="test"
 ```
 
 Available schema validation modes (`--schema-mode`):
+
 - `compatible` (default)
   - Input schema: new optional fields OK, required fields must have the same type.
   - Output schema: new fields OK, removed required fields cause error.
@@ -668,6 +681,73 @@ To help Claude Code use `mcpc`, you can install this [Claude skill](./docs/claud
 
 <!-- TODO: Add also AGENTS.md, GitHub skills etc. -->
 
+## Agentic payments (x402)
+
+> **Experimental.** This feature is under active development and may change.
+
+`mcpc` has experimental support for the [x402 payment protocol](https://www.x402.org/),
+which enables AI agents to autonomously pay for MCP tool calls using cryptocurrency.
+When an MCP server charges for a tool call (HTTP 402), `mcpc` automatically signs a USDC payment
+on the [Base](https://base.org/) blockchain and retries the request — no human intervention needed.
+
+This is entirely **opt-in**: existing functionality is unaffected unless you explicitly pass the `--x402` flag.
+
+### How it works
+
+1. **Server returns HTTP 402** with a `PAYMENT-REQUIRED` header describing the price and payment details.
+2. `mcpc` parses the header, signs an [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) `TransferWithAuthorization` using your local wallet.
+3. `mcpc` retries the request with a `PAYMENT-SIGNATURE` header containing the signed payment.
+4. The server verifies the signature and fulfills the request.
+
+For tools that advertise pricing in their `_meta.x402` metadata, `mcpc` can **proactively sign** payments
+on the first request, avoiding the 402 round-trip entirely.
+
+### Wallet setup
+
+`mcpc` stores a single wallet in `~/.mcpc/wallets.json` (file permissions `0600`).
+You need to create or import a wallet before using x402 payments.
+
+```bash
+# Create a new wallet (generates a random private key)
+mcpc x402 init
+
+# Or import an existing wallet from a private key
+mcpc x402 import <private-key>
+
+# Show wallet address and creation date
+mcpc x402 info
+
+# Remove the wallet
+mcpc x402 remove
+```
+
+After creating a wallet, **fund it with USDC on Base** (mainnet or Sepolia testnet) to enable payments.
+
+### Using x402 with MCP servers
+
+Pass the `--x402` flag when connecting to a session or running direct commands:
+
+```bash
+# Create a session with x402 payment support
+mcpc mcp.apify.com connect @apify --x402
+
+# The session now automatically handles 402 responses
+mcpc @apify tools-call expensive-tool query:="hello"
+
+# Restart a session with x402 enabled
+mcpc @apify restart --x402
+```
+
+When `--x402` is active, a fetch middleware wraps all HTTP requests to the MCP server.
+If any request returns HTTP 402, the middleware transparently signs and retries.
+
+### Supported networks
+
+| Network              | Status       |
+| -------------------- | ------------ |
+| Base Mainnet         | ✅ Supported |
+| Base Sepolia testnet | ✅ Supported |
+
 ## MCP support
 
 `mcpc` is built on the official [MCP SDK for TypeScript](https://github.com/modelcontextprotocol/typescript-sdk) and supports most [MCP protocol features](https://modelcontextprotocol.io/specification/latest).
@@ -688,6 +768,7 @@ To help Claude Code use `mcpc`, you can install this [Claude skill](./docs/claud
 ### MCP session
 
 The bridge process manages the full MCP session lifecycle:
+
 - Performs initialization handshake (`initialize` → `initialized`)
 - Negotiates protocol version and capabilities
 - Fetches server-provided `instructions`
@@ -698,21 +779,21 @@ The bridge process manages the full MCP session lifecycle:
 
 ### MCP feature support
 
-| **Feature**                                        | **Status**                         |
-|:---------------------------------------------------|:-----------------------------------|
-| 📖 [**Instructions**](#server-instructions)        | ✅ Supported                        |
-| 🔧 [**Tools**](#tools)                             | ✅ Supported                        |
-| 💬 [**Prompts**](#prompts)                         | ✅ Supported                        |
-| 📦 [**Resources**](#resources)                     | ✅ Supported                        |
-| 📝 [**Logging**](#server-logs)                     | ✅ Supported                        |
-| 🔔 [**Notifications**](#list-change-notifications) | ✅ Supported                        |
-| 📄 [**Pagination**](#pagination)                   | ✅ Supported                        |
-| 🏓 [**Ping**](#ping)                               | ✅ Supported                        |
-| ⏳ **Async tasks**                                  | 🚧 Planned                         |
-| 📁 **Roots**                                       | 🚧 Planned                         |
-| ❓ **Elicitation**                                  | 🚧 Planned                         |
-| 🔤 **Completion**                                  | 🚧 Planned                         |
-| 🤖 **Sampling**                                    | ❌ Not applicable (no LLM access)   |
+| **Feature**                                        | **Status**                        |
+| :------------------------------------------------- | :-------------------------------- |
+| 📖 [**Instructions**](#server-instructions)        | ✅ Supported                      |
+| 🔧 [**Tools**](#tools)                             | ✅ Supported                      |
+| 💬 [**Prompts**](#prompts)                         | ✅ Supported                      |
+| 📦 [**Resources**](#resources)                     | ✅ Supported                      |
+| 📝 [**Logging**](#server-logs)                     | ✅ Supported                      |
+| 🔔 [**Notifications**](#list-change-notifications) | ✅ Supported                      |
+| 📄 [**Pagination**](#pagination)                   | ✅ Supported                      |
+| 🏓 [**Ping**](#ping)                               | ✅ Supported                      |
+| ⏳ **Async tasks**                                 | 🚧 Planned                        |
+| 📁 **Roots**                                       | 🚧 Planned                        |
+| ❓ **Elicitation**                                 | 🚧 Planned                        |
+| 🔤 **Completion**                                  | 🚧 Planned                        |
+| 🤖 **Sampling**                                    | ❌ Not applicable (no LLM access) |
 
 #### Server instructions
 
@@ -865,6 +946,7 @@ mcpc @apify ping --json
 You can configure `mcpc` using a config file, environment variables, or command-line flags.
 
 **Precedence** (highest to lowest):
+
 1. Command-line flags (including `--config` option)
 2. Environment variables
 3. Built-in defaults
@@ -912,11 +994,13 @@ mcpc --config .vscode/mcp.json apify connect @my-apify
 **Server configuration properties:**
 
 For **Streamable HTTP servers:**
+
 - `url` (required) - MCP server endpoint URL
 - `headers` (optional) - HTTP headers to include with requests
 - `timeout` (optional) - Request timeout in seconds
 
 For **stdio servers:**
+
 - `command` (required) - Command to execute (e.g., `node`, `npx`, `python`)
 - `args` (optional) - Array of command arguments
 - `env` (optional) - Environment variables for the process
@@ -958,6 +1042,7 @@ Config files support environment variable substitution using `${VAR_NAME}` synta
 
 - `~/.mcpc/sessions.json` - Active sessions with references to authentication profiles (file-locked for concurrent access)
 - `~/.mcpc/profiles.json` - Authentication profiles (OAuth metadata, scopes, expiry)
+- `~/.mcpc/wallets.json` - x402 wallet data (file permissions `0600`)
 - `~/.mcpc/bridges/` - Unix domain socket files for each bridge process
 - `~/.mcpc/logs/bridge-*.log` - Log files for each bridge process
 - OS keychain - Sensitive credentials (OAuth tokens, bearer tokens, client secrets)
@@ -1000,11 +1085,12 @@ MCP enables arbitrary tool execution and data access - treat servers like you tr
 ### Credential protection
 
 | What                   | How                                             |
-|------------------------|-------------------------------------------------|
+| ---------------------- | ----------------------------------------------- |
 | **OAuth tokens**       | Stored in OS keychain, never on disk            |
 | **HTTP headers**       | Stored in OS keychain per-session               |
 | **Bridge credentials** | Passed via Unix socket IPC, kept in memory only |
 | **Process arguments**  | No secrets visible in `ps aux`                  |
+| **x402 private key**   | Stored in `wallets.json` (`0600` permissions)   |
 | **Config files**       | Contain only metadata, never tokens             |
 | **File permissions**   | `0600` (user-only) for all config files         |
 
@@ -1055,19 +1141,21 @@ The main `mcpc` process doesn't save log files, but supports [verbose mode](#ver
 ### Troubleshooting
 
 **"Cannot connect to bridge"**
+
 - Bridge may have crashed. Try: `mcpc @<session-name> tools-list` to restart the bridge
 - Check bridge is running: `ps aux | grep -e 'mcpc-bridge' -e '[m]cpc/dist/bridge'`
 - Check socket exists: `ls ~/.mcpc/bridges/`
 
 **"Session not found"**
+
 - List existing sessions: `mcpc`
 - Create new session if expired: `mcpc @<session-name> close` and `mcpc <target> connect @<session-name>`
 
 **"Authentication failed"**
+
 - List saved OAuth profiles: `mcpc`
 - Re-authenticate: `mcpc <server> login [--profile <name>]`
 - For bearer tokens: provide `--header "Authorization: Bearer ${TOKEN}"` again
-
 
 ## Development
 
@@ -1099,8 +1187,6 @@ See [CONTRIBUTING](./CONTRIBUTING.md) for development setup, architecture overvi
 - Other
   - https://github.com/TeamSparkAI/mcpGraph
 
-
 ## License
 
 Apache-2.0 - see [LICENSE](./LICENSE) for details.
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ After all, UNIX-compatible shell script is THE most universal coding language.
 - 🤖 **AI sandboxing** - MCP proxy server to securely access authenticated sessions from AI-generated code.
 - 🔒 **Secure** - Full OAuth 2.1 support, OS keychain for credentials storage.
 - 🪶 **Lightweight** - Minimal dependencies, works on Mac/Win/Linux, doesn't use LLMs on its own.
-- 💸 **[Agentic payments (x402)](#agentic-payments-x402)** - Experimental support for the [x402](https://www.x402.org/) payment protocol, enabling AI agents to pay for MCP tool calls with USDC on Base.
+- 💸 **[Agentic payments (x402)](#agentic-payments-x402)** - Experimental support for the [x402](https://www.x402.org/) payment protocol, enabling AI agents to pay for MCP tool calls with USDC on [Base](https://www.base.org/).
 
 ## Table of contents
 
@@ -683,7 +683,7 @@ To help Claude Code use `mcpc`, you can install this [Claude skill](./docs/claud
 
 ## Agentic payments (x402)
 
-> **Experimental.** This feature is under active development and may change.
+> ⚠️ **Experimental.** This feature is under active development and may change.
 
 `mcpc` has experimental support for the [x402 payment protocol](https://www.x402.org/),
 which enables AI agents to autonomously pay for MCP tool calls using cryptocurrency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "ora": "^9.0.0",
         "proper-lockfile": "^4.1.2",
         "undici": "^7.22.0",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "viem": "^2.46.3"
       },
       "bin": {
         "mcpc": "bin/mcpc",
@@ -46,6 +47,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2390,6 +2397,45 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2502,6 +2548,42 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3246,6 +3328,27 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -5647,6 +5750,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -7413,6 +7522,21 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -10109,6 +10233,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ox": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.12.4.tgz",
+      "integrity": "sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12382,7 +12536,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -12677,6 +12831,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.46.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.46.3.tgz",
+      "integrity": "sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.12.4",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/walker": {
@@ -12989,6 +13173,28 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xmlbuilder2": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "ora": "^9.0.0",
     "proper-lockfile": "^4.1.2",
     "undici": "^7.22.0",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "viem": "^2.46.3"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -54,7 +54,7 @@ interface BridgeOptions {
   profileName?: string; // Auth profile name for token refresh
   proxyConfig?: ProxyConfig; // Proxy server configuration
   mcpSessionId?: string; // MCP session ID for resumption (Streamable HTTP only)
-  walletName?: string; // x402 wallet name for automatic payment signing
+  x402?: boolean; // Enable x402 auto-payment
 }
 
 /**
@@ -223,7 +223,7 @@ class BridgeProcess {
    * The wallet private key is used for automatic payment signing
    */
   setX402Wallet(credentials: X402WalletCredentials): void {
-    logger.info(`Received x402 wallet: ${credentials.walletName} (${credentials.address})`);
+    logger.info(`Received x402 wallet: ${credentials.address}`);
     this.x402Wallet = {
       privateKey: credentials.privateKey,
       address: credentials.address,
@@ -343,8 +343,8 @@ class BridgeProcess {
         ipcWaiters.push(this.authCredentialsReceived);
       }
 
-      if (this.options.walletName) {
-        logger.debug(`Waiting for x402 wallet (wallet: ${this.options.walletName})...`);
+      if (this.options.x402) {
+        logger.debug('Waiting for x402 wallet...');
         this.x402WalletReceived = new Promise<void>((resolve) => {
           this.x402WalletResolver = resolve;
         });
@@ -1137,7 +1137,7 @@ async function main(): Promise<void> {
 
   if (args.length < 2) {
     console.error(
-      'Usage: mcpc-bridge <sessionName> <transportConfigJson> [--verbose] [--profile <name>] [--proxy-host <host>] [--proxy-port <port>] [--mcp-session-id <id>] [--wallet <name>]'
+      'Usage: mcpc-bridge <sessionName> <transportConfigJson> [--verbose] [--profile <name>] [--proxy-host <host>] [--proxy-port <port>] [--mcp-session-id <id>] [--x402]'
     );
     process.exit(1);
   }
@@ -1172,12 +1172,8 @@ async function main(): Promise<void> {
     mcpSessionId = args[mcpSessionIdIndex + 1];
   }
 
-  // Parse --wallet argument (for x402 payment signing)
-  let walletName: string | undefined;
-  const walletIndex = args.indexOf('--wallet');
-  if (walletIndex !== -1 && args[walletIndex + 1]) {
-    walletName = args[walletIndex + 1];
-  }
+  // Parse --x402 flag (for x402 payment signing)
+  const x402 = args.includes('--x402');
 
   try {
     const bridgeOptions: BridgeOptions = {
@@ -1194,8 +1190,8 @@ async function main(): Promise<void> {
     if (mcpSessionId) {
       bridgeOptions.mcpSessionId = mcpSessionId;
     }
-    if (walletName) {
-      bridgeOptions.walletName = walletName;
+    if (x402) {
+      bridgeOptions.x402 = true;
     }
 
     const bridge = new BridgeProcess(bridgeOptions);

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -22,7 +22,7 @@ import {
 } from '../lib/index.js';
 import { ClientError, NetworkError, isAuthenticationError } from '../lib/index.js';
 import { loadSessions, updateSession } from '../lib/sessions.js';
-import type { AuthCredentials } from '../lib/types.js';
+import type { AuthCredentials, X402WalletCredentials } from '../lib/types.js';
 import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
 import { OAuthProvider } from '../lib/auth/oauth-provider.js';
 import { storeKeychainOAuthTokenInfo, readKeychainOAuthTokenInfo } from '../lib/auth/keychain.js';
@@ -35,6 +35,9 @@ const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.j
 };
 import { ProxyServer } from './proxy-server.js';
 import type { ProxyConfig } from '../lib/types.js';
+import { createX402FetchMiddleware } from '../lib/x402/fetch-middleware.js';
+import type { SignerWallet } from '../lib/x402/signer.js';
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 // Set up HTTP proxy from environment variables (HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and lowercase variants)
 setGlobalDispatcher(new EnvHttpProxyAgent());
@@ -51,6 +54,7 @@ interface BridgeOptions {
   profileName?: string; // Auth profile name for token refresh
   proxyConfig?: ProxyConfig; // Proxy server configuration
   mcpSessionId?: string; // MCP session ID for resumption (Streamable HTTP only)
+  walletName?: string; // x402 wallet name for automatic payment signing
 }
 
 /**
@@ -76,9 +80,19 @@ class BridgeProcess {
   // HTTP headers (received via IPC, stored in memory only)
   private headers: Record<string, string> | null = null;
 
+  // x402 wallet for automatic payment signing (received via IPC, stored in memory only)
+  private x402Wallet: SignerWallet | null = null;
+
+  // Cached tools list for x402 proactive signing (updated via listChanged notifications)
+  private cachedTools: Tool[] | null = null;
+
   // Promise to track when auth credentials are received (for startup sequencing)
   private authCredentialsReceived: Promise<void> | null = null;
   private authCredentialsResolver: (() => void) | null = null;
+
+  // Promise to track when x402 wallet is received (for startup sequencing)
+  private x402WalletReceived: Promise<void> | null = null;
+  private x402WalletResolver: (() => void) | null = null;
 
   // Promise to track when MCP client is connected (for blocking requests until ready)
   private mcpClientReady: Promise<void>;
@@ -205,6 +219,25 @@ class BridgeProcess {
   }
 
   /**
+   * Set x402 wallet received from CLI via IPC
+   * The wallet private key is used for automatic payment signing
+   */
+  setX402Wallet(credentials: X402WalletCredentials): void {
+    logger.info(`Received x402 wallet: ${credentials.walletName} (${credentials.address})`);
+    this.x402Wallet = {
+      privateKey: credentials.privateKey,
+      address: credentials.address,
+    };
+    logger.debug('x402 wallet stored in memory');
+
+    // Signal that wallet has been received (unblocks startup)
+    if (this.x402WalletResolver) {
+      this.x402WalletResolver();
+      this.x402WalletResolver = null;
+    }
+  }
+
+  /**
    * Get a valid access token, refreshing if necessary,
    * and update transport config with headers
    *
@@ -298,23 +331,33 @@ class BridgeProcess {
       // 3. Create Unix socket server FIRST (so CLI can send auth credentials)
       await this.createSocketServer();
 
-      // 4. Wait for auth credentials from CLI if auth profile is specified
-      // The CLI sends credentials via IPC immediately after detecting the socket file
+      // 4. Wait for auth credentials and/or x402 wallet from CLI via IPC
+      // The CLI sends these immediately after detecting the socket file
+      const ipcWaiters: Promise<void>[] = [];
+
       if (this.options.profileName) {
         logger.debug(`Waiting for auth credentials (profile: ${this.options.profileName})...`);
-
-        // Create a promise that resolves when credentials are received
         this.authCredentialsReceived = new Promise<void>((resolve) => {
           this.authCredentialsResolver = resolve;
         });
+        ipcWaiters.push(this.authCredentialsReceived);
+      }
 
+      if (this.options.walletName) {
+        logger.debug(`Waiting for x402 wallet (wallet: ${this.options.walletName})...`);
+        this.x402WalletReceived = new Promise<void>((resolve) => {
+          this.x402WalletResolver = resolve;
+        });
+        ipcWaiters.push(this.x402WalletReceived);
+      }
+
+      if (ipcWaiters.length > 0) {
         // Wait with timeout (5 seconds should be plenty for local IPC)
         const timeout = new Promise<void>((_, reject) => {
-          setTimeout(() => reject(new Error('Timeout waiting for auth credentials')), 5000);
+          setTimeout(() => reject(new Error('Timeout waiting for IPC credentials')), 5000);
         });
-
-        await Promise.race([this.authCredentialsReceived, timeout]);
-        logger.debug('Auth credentials received, proceeding with MCP connection');
+        await Promise.race([Promise.all(ipcWaiters), timeout]);
+        logger.debug('IPC credentials received, proceeding with MCP connection');
       }
 
       // 5. Connect to MCP server (now with auth credentials if provided)
@@ -445,8 +488,23 @@ class BridgeProcess {
 
     logger.debug('Building MCP client config...');
     logger.debug(`  this.authProvider is set: ${!!this.authProvider}`);
+    logger.debug(`  this.x402Wallet is set: ${!!this.x402Wallet}`);
     if (this.authProvider) {
       logger.debug(`  authProvider type: ${this.authProvider.constructor.name}`);
+    }
+
+    // Build x402 fetch middleware if wallet is configured
+    let customFetch: FetchLike | undefined;
+    if (this.x402Wallet && serverConfig.url) {
+      logger.debug('Creating x402 fetch middleware for payment signing');
+      // We use a closure that defers tool lookup to the connected client
+      // The client may not have tools cached yet at this point, but will
+      // after it connects and receives the auto-refreshed tools list
+      const wallet = this.x402Wallet;
+      const getToolByName = (name: string): Tool | undefined => {
+        return this.cachedTools?.find((t: Tool) => t.name === name);
+      };
+      customFetch = createX402FetchMiddleware(fetch, { wallet, getToolByName });
     }
 
     const clientConfig: CreateMcpClientOptions = {
@@ -460,6 +518,8 @@ class BridgeProcess {
       ...(this.authProvider && { authProvider: this.authProvider }),
       // Pass session ID for resumption (HTTP transport only)
       ...(this.options.mcpSessionId && { mcpSessionId: this.options.mcpSessionId }),
+      // Pass x402 fetch middleware (HTTP transport only)
+      ...(customFetch && { customFetch }),
       listChanged: {
         tools: {
           // Let SDK auto-fetch the tools on list changed notification.
@@ -467,6 +527,11 @@ class BridgeProcess {
           autoRefresh: true,
           onChanged: (error: Error | null, tools: Tool[] | null) => {
             logger.debug('Tools list changed', { error, count: tools?.length });
+            // Update local tools cache (used by x402 middleware for proactive signing)
+            if (tools) {
+              this.cachedTools = tools;
+              logger.debug(`Updated cached tools list (${tools.length} tools)`);
+            }
             // Broadcast notification to all connected clients
             this.broadcastNotification('tools/list_changed');
             // Update session with notification timestamp
@@ -539,6 +604,20 @@ class BridgeProcess {
     // Note: Token refresh is handled automatically by the SDK
     // The SDK calls authProvider.tokens() before each request,
     // which triggers OAuthTokenManager.getValidAccessToken() to refresh if needed
+
+    // Pre-populate tools cache for x402 proactive signing
+    if (this.x402Wallet) {
+      try {
+        const toolsResult = await this.client.listTools();
+        if (toolsResult.tools) {
+          this.cachedTools = toolsResult.tools;
+          logger.debug(`Pre-populated tools cache (${this.cachedTools.length} tools) for x402`);
+        }
+      } catch (error) {
+        // Non-fatal: 402 fallback will still work without proactive signing
+        logger.warn('Failed to pre-populate tools cache for x402:', error);
+      }
+    }
   }
 
   /**
@@ -772,6 +851,21 @@ class BridgeProcess {
             }
           } else {
             throw new ClientError('Missing authCredentials in set-auth-credentials message');
+          }
+          break;
+
+        case 'set-x402-wallet':
+          if (message.x402Wallet) {
+            this.setX402Wallet(message.x402Wallet);
+            if (message.id) {
+              this.sendResponse(socket, {
+                type: 'response',
+                id: message.id,
+                result: { success: true },
+              });
+            }
+          } else {
+            throw new ClientError('Missing x402Wallet in set-x402-wallet message');
           }
           break;
 
@@ -1043,7 +1137,7 @@ async function main(): Promise<void> {
 
   if (args.length < 2) {
     console.error(
-      'Usage: mcpc-bridge <sessionName> <transportConfigJson> [--verbose] [--profile <name>] [--proxy-host <host>] [--proxy-port <port>] [--mcp-session-id <id>]'
+      'Usage: mcpc-bridge <sessionName> <transportConfigJson> [--verbose] [--profile <name>] [--proxy-host <host>] [--proxy-port <port>] [--mcp-session-id <id>] [--wallet <name>]'
     );
     process.exit(1);
   }
@@ -1078,6 +1172,13 @@ async function main(): Promise<void> {
     mcpSessionId = args[mcpSessionIdIndex + 1];
   }
 
+  // Parse --wallet argument (for x402 payment signing)
+  let walletName: string | undefined;
+  const walletIndex = args.indexOf('--wallet');
+  if (walletIndex !== -1 && args[walletIndex + 1]) {
+    walletName = args[walletIndex + 1];
+  }
+
   try {
     const bridgeOptions: BridgeOptions = {
       sessionName,
@@ -1092,6 +1193,9 @@ async function main(): Promise<void> {
     }
     if (mcpSessionId) {
       bridgeOptions.mcpSessionId = mcpSessionId;
+    }
+    if (walletName) {
+      bridgeOptions.walletName = walletName;
     }
 
     const bridge = new BridgeProcess(bridgeOptions);

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -10,3 +10,4 @@ export * from './sessions.js';
 export * from './logging.js';
 export * from './utilities.js';
 export * from './auth.js';
+export * from './x402.js';

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -35,7 +35,7 @@ import {
   storeKeychainProxyBearerToken,
 } from '../../lib/auth/keychain.js';
 import { AuthError, ClientError } from '../../lib/index.js';
-import { getWallet, resolveWalletName } from '../../lib/wallets.js';
+import { getWallet } from '../../lib/wallets.js';
 import chalk from 'chalk';
 import { createLogger } from '../../lib/logger.js';
 import { parseProxyArg } from '../parser.js';
@@ -84,7 +84,7 @@ export async function connectSession(
     profile?: string;
     proxy?: string;
     proxyBearerToken?: string;
-    x402?: string;
+    x402?: boolean;
   }
 ): Promise<void> {
   try {
@@ -196,16 +196,12 @@ export async function connectSession(
     }
 
     // Validate x402 wallet (if provided)
-    let walletName: string | undefined;
     if (options.x402) {
-      walletName = resolveWalletName(options.x402);
-      const wallet = await getWallet(walletName);
+      const wallet = await getWallet();
       if (!wallet) {
-        throw new ClientError(
-          `x402 wallet "${walletName}" not found. Create one with: mcpc x402 init --name ${walletName}`
-        );
+        throw new ClientError('x402 wallet not found. Create one with: mcpc x402 init');
       }
-      logger.debug(`Using x402 wallet: ${walletName} (${wallet.address})`);
+      logger.debug(`Using x402 wallet: ${wallet.address}`);
     }
 
     // Create or update session record (without pid - that comes from startBridge)
@@ -221,7 +217,7 @@ export async function connectSession(
       server: sessionTransportConfig,
       ...(profileName && { profileName }),
       ...(proxyConfig && { proxy: proxyConfig }),
-      ...(walletName && { walletName }),
+      ...(options.x402 && { x402: true }),
     };
 
     if (isReconnect) {
@@ -252,8 +248,8 @@ export async function connectSession(
       if (proxyConfig) {
         bridgeOptions.proxyConfig = proxyConfig;
       }
-      if (walletName) {
-        bridgeOptions.walletName = walletName;
+      if (options.x402) {
+        bridgeOptions.x402 = true;
       }
 
       const { pid } = await startBridge(bridgeOptions);
@@ -611,8 +607,8 @@ export async function restartSession(
       bridgeOptions.proxyConfig = session.proxy;
     }
 
-    if (session.walletName) {
-      bridgeOptions.walletName = session.walletName;
+    if (session.x402) {
+      bridgeOptions.x402 = session.x402;
     }
 
     // NOTE: Do NOT pass mcpSessionId on explicit restart.

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -35,6 +35,7 @@ import {
   storeKeychainProxyBearerToken,
 } from '../../lib/auth/keychain.js';
 import { AuthError, ClientError } from '../../lib/index.js';
+import { getWallet, resolveWalletName } from '../../lib/wallets.js';
 import chalk from 'chalk';
 import { createLogger } from '../../lib/logger.js';
 import { parseProxyArg } from '../parser.js';
@@ -83,6 +84,7 @@ export async function connectSession(
     profile?: string;
     proxy?: string;
     proxyBearerToken?: string;
+    x402?: string;
   }
 ): Promise<void> {
   try {
@@ -193,6 +195,19 @@ export async function connectSession(
       await storeKeychainProxyBearerToken(name, options.proxyBearerToken);
     }
 
+    // Validate x402 wallet (if provided)
+    let walletName: string | undefined;
+    if (options.x402) {
+      walletName = resolveWalletName(options.x402);
+      const wallet = await getWallet(walletName);
+      if (!wallet) {
+        throw new ClientError(
+          `x402 wallet "${walletName}" not found. Create one with: mcpc x402 init --name ${walletName}`
+        );
+      }
+      logger.debug(`Using x402 wallet: ${walletName} (${wallet.address})`);
+    }
+
     // Create or update session record (without pid - that comes from startBridge)
     // Store serverConfig with headers redacted (actual values in keychain)
     const isReconnect = !!existingSession;
@@ -206,6 +221,7 @@ export async function connectSession(
       server: sessionTransportConfig,
       ...(profileName && { profileName }),
       ...(proxyConfig && { proxy: proxyConfig }),
+      ...(walletName && { walletName }),
     };
 
     if (isReconnect) {
@@ -235,6 +251,9 @@ export async function connectSession(
       }
       if (proxyConfig) {
         bridgeOptions.proxyConfig = proxyConfig;
+      }
+      if (walletName) {
+        bridgeOptions.walletName = walletName;
       }
 
       const { pid } = await startBridge(bridgeOptions);
@@ -590,6 +609,10 @@ export async function restartSession(
 
     if (session.proxy) {
       bridgeOptions.proxyConfig = session.proxy;
+    }
+
+    if (session.walletName) {
+      bridgeOptions.walletName = session.walletName;
     }
 
     // NOTE: Do NOT pass mcpSessionId on explicit restart.

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -1,0 +1,509 @@
+/**
+ * x402 wallet management and payment signing commands
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { createWalletClient, http, type Hex } from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+import { formatSuccess, formatError, formatInfo, formatJson } from '../output.js';
+import {
+  loadWallets,
+  getWallet,
+  saveWallet,
+  removeWallet,
+  resolveWalletName,
+} from '../../lib/wallets.js';
+import { ClientError } from '../../lib/errors.js';
+import type { OutputMode } from '../../lib/types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WALLET_NAME = 'default';
+const USDC_DECIMALS = 6;
+const X402_VERSION = 2;
+
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+} as const;
+
+interface NetworkConfig {
+  chain: typeof base | typeof baseSepolia;
+  networkId: string;
+  rpcUrl: string;
+  label: string;
+}
+
+const NETWORKS: Record<string, NetworkConfig> = {
+  [`eip155:${base.id}`]: {
+    chain: base,
+    networkId: `eip155:${base.id}`,
+    rpcUrl: 'https://mainnet.base.org',
+    label: 'Base Mainnet',
+  },
+  [`eip155:${baseSepolia.id}`]: {
+    chain: baseSepolia,
+    networkId: `eip155:${baseSepolia.id}`,
+    rpcUrl: 'https://sepolia.base.org',
+    label: 'Base Sepolia (testnet)',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// PAYMENT-REQUIRED header parsing
+// ---------------------------------------------------------------------------
+
+interface PaymentRequiredAccept {
+  scheme: string;
+  network: string;
+  amount: string;
+  asset: string;
+  payTo: string;
+  maxTimeoutSeconds: number;
+  extra?: { name?: string; version?: string };
+}
+
+interface PaymentRequiredHeader {
+  x402Version: number;
+  resource?: { url?: string; description?: string; mimeType?: string };
+  accepts: PaymentRequiredAccept[];
+}
+
+function parsePaymentRequired(base64Value: string): {
+  header: PaymentRequiredHeader;
+  accept: PaymentRequiredAccept;
+} {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(base64Value, 'base64').toString('utf-8');
+  } catch {
+    throw new ClientError('Failed to base64-decode the --payment-required value.');
+  }
+
+  let header: PaymentRequiredHeader;
+  try {
+    header = JSON.parse(decoded) as PaymentRequiredHeader;
+  } catch {
+    throw new ClientError('PAYMENT-REQUIRED header is not valid JSON after base64 decoding.');
+  }
+
+  if (!header.accepts || !Array.isArray(header.accepts) || header.accepts.length === 0) {
+    throw new ClientError('PAYMENT-REQUIRED header has no "accepts" entries.');
+  }
+
+  const accept = header.accepts.find((a) => a.scheme === 'exact');
+  if (!accept) {
+    throw new ClientError(
+      `No "exact" scheme found in PAYMENT-REQUIRED accepts. Available: ${header.accepts.map((a) => a.scheme).join(', ')}`
+    );
+  }
+
+  if (!accept.payTo || !accept.amount || !accept.network || !accept.asset) {
+    throw new ClientError(
+      'PAYMENT-REQUIRED accept entry is missing required fields (payTo, amount, network, asset).'
+    );
+  }
+
+  return { header, accept };
+}
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
+
+function randomBytes32(): Hex {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return ('0x' + [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')) as Hex;
+}
+
+// ---------------------------------------------------------------------------
+// Command: init
+// ---------------------------------------------------------------------------
+
+async function initWallet(options: { name?: string; outputMode: OutputMode }): Promise<void> {
+  const name = resolveWalletName(options.name);
+
+  const existing = await getWallet(name);
+  if (existing) {
+    throw new ClientError(
+      `Wallet "${name}" already exists (address: ${existing.address}). Use "mcpc x402 remove --name ${name}" first.`
+    );
+  }
+
+  const privateKey = generatePrivateKey();
+  const account = privateKeyToAccount(privateKey);
+
+  await saveWallet({
+    name,
+    address: account.address,
+    privateKey,
+    createdAt: new Date().toISOString(),
+  });
+
+  if (options.outputMode === 'json') {
+    console.log(formatJson({ name, address: account.address }));
+  } else {
+    console.log(formatSuccess(`Wallet "${name}" created`));
+    console.log(formatInfo(`Address: ${chalk.cyan(account.address)}`));
+    console.log(formatInfo('Fund this address with USDC on Base to use x402 payments.'));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: import
+// ---------------------------------------------------------------------------
+
+async function importWallet(options: {
+  name?: string;
+  privateKey: string;
+  outputMode: OutputMode;
+}): Promise<void> {
+  const name = resolveWalletName(options.name);
+
+  const existing = await getWallet(name);
+  if (existing) {
+    throw new ClientError(
+      `Wallet "${name}" already exists (address: ${existing.address}). Use "mcpc x402 remove --name ${name}" first.`
+    );
+  }
+
+  let key = options.privateKey.trim();
+  if (!key.startsWith('0x')) key = `0x${key}`;
+
+  let account;
+  try {
+    account = privateKeyToAccount(key as Hex);
+  } catch {
+    throw new ClientError(
+      'Invalid private key. Must be a 64-character hex string (with or without 0x prefix).'
+    );
+  }
+
+  await saveWallet({
+    name,
+    address: account.address,
+    privateKey: key,
+    createdAt: new Date().toISOString(),
+  });
+
+  if (options.outputMode === 'json') {
+    console.log(formatJson({ name, address: account.address }));
+  } else {
+    console.log(formatSuccess(`Wallet "${name}" imported`));
+    console.log(formatInfo(`Address: ${chalk.cyan(account.address)}`));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: list
+// ---------------------------------------------------------------------------
+
+async function listWallets(options: { outputMode: OutputMode }): Promise<void> {
+  const storage = await loadWallets();
+  const wallets = Object.values(storage.wallets);
+
+  if (options.outputMode === 'json') {
+    console.log(
+      formatJson(wallets.map((w) => ({ name: w.name, address: w.address, createdAt: w.createdAt })))
+    );
+    return;
+  }
+
+  if (wallets.length === 0) {
+    console.log(formatInfo('No wallets found. Create one with: mcpc x402 init'));
+    return;
+  }
+
+  for (const w of wallets) {
+    const isDefault = w.name === DEFAULT_WALLET_NAME ? chalk.dim(' (default)') : '';
+    console.log(`  ${chalk.bold(w.name)}${isDefault}  ${chalk.cyan(w.address)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: remove
+// ---------------------------------------------------------------------------
+
+async function removeWalletCmd(options: { name?: string; outputMode: OutputMode }): Promise<void> {
+  const name = resolveWalletName(options.name);
+
+  const removed = await removeWallet(name);
+  if (!removed) {
+    throw new ClientError(`Wallet "${name}" not found.`);
+  }
+
+  if (options.outputMode === 'json') {
+    console.log(formatJson({ name, removed: true }));
+  } else {
+    console.log(formatSuccess(`Wallet "${name}" removed.`));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command: sign
+// ---------------------------------------------------------------------------
+
+interface SignOptions {
+  name?: string;
+  paymentRequired: string;
+  amount?: string;
+  expiry?: string;
+  outputMode: OutputMode;
+}
+
+async function signPayment(options: SignOptions): Promise<void> {
+  const name = resolveWalletName(options.name);
+
+  const wallet = await getWallet(name);
+  if (!wallet) {
+    throw new ClientError(
+      `Wallet "${name}" not found. Create one with: mcpc x402 init --name ${name}`
+    );
+  }
+
+  // Parse PAYMENT-REQUIRED header
+  const { header, accept } = parsePaymentRequired(options.paymentRequired);
+
+  // Resolve network
+  const networkConfig = NETWORKS[accept.network];
+  if (!networkConfig) {
+    throw new ClientError(
+      `Unknown network "${accept.network}" in PAYMENT-REQUIRED. Supported: ${Object.keys(NETWORKS).join(', ')}`
+    );
+  }
+
+  // Resolve amount (CLI override or from header)
+  let amountAtomicUnits: bigint;
+  let amountUsd: number;
+  if (options.amount) {
+    amountUsd = parseFloat(options.amount);
+    if (isNaN(amountUsd) || amountUsd <= 0)
+      throw new ClientError('--amount must be a positive number.');
+    amountAtomicUnits = BigInt(Math.round(amountUsd * 10 ** USDC_DECIMALS));
+  } else {
+    amountAtomicUnits = BigInt(accept.amount);
+    amountUsd = Number(amountAtomicUnits) / 10 ** USDC_DECIMALS;
+  }
+
+  // Resolve expiry
+  const expirySeconds = options.expiry
+    ? parseInt(options.expiry, 10)
+    : accept.maxTimeoutSeconds || 3600;
+
+  // EIP-3009 domain from header extra or defaults
+  const eip3009Name = accept.extra?.name ?? 'USDC';
+  const eip3009Version = accept.extra?.version ?? '2';
+
+  // Resource from header
+  const resource = header.resource ?? {
+    url: 'https://mcp.apify.com/mcp',
+    description: 'MCP Server',
+    mimeType: 'application/json',
+  };
+
+  // Sign
+  const account = privateKeyToAccount(wallet.privateKey as Hex);
+  const walletClient = createWalletClient({
+    account,
+    chain: networkConfig.chain,
+    transport: http(networkConfig.rpcUrl),
+  });
+
+  const nonce = randomBytes32();
+  const validBefore = BigInt(Math.floor(Date.now() / 1000) + expirySeconds);
+
+  const signature = await walletClient.signTypedData({
+    domain: {
+      name: eip3009Name,
+      version: eip3009Version,
+      chainId: networkConfig.chain.id,
+      verifyingContract: accept.asset as Hex,
+    },
+    types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+    primaryType: 'TransferWithAuthorization',
+    message: {
+      from: account.address,
+      to: accept.payTo as Hex,
+      value: amountAtomicUnits,
+      validAfter: 0n,
+      validBefore,
+      nonce,
+    },
+  });
+
+  // Build x402 payload
+  const paymentPayload = {
+    x402Version: X402_VERSION,
+    resource,
+    payload: {
+      signature,
+      authorization: {
+        from: account.address,
+        to: accept.payTo,
+        value: amountAtomicUnits.toString(),
+        validAfter: '0',
+        validBefore: validBefore.toString(),
+        nonce,
+      },
+    },
+    accepted: {
+      scheme: 'exact',
+      network: networkConfig.networkId,
+      asset: accept.asset,
+      amount: amountAtomicUnits.toString(),
+      payTo: accept.payTo,
+      maxTimeoutSeconds: expirySeconds,
+      extra: { name: eip3009Name, version: eip3009Version },
+    },
+  };
+
+  const payloadBase64 = Buffer.from(JSON.stringify(paymentPayload)).toString('base64');
+
+  if (options.outputMode === 'json') {
+    console.log(
+      formatJson({
+        paymentSignature: payloadBase64,
+        from: account.address,
+        to: accept.payTo,
+        amount: amountUsd,
+        amountAtomicUnits: amountAtomicUnits.toString(),
+        network: networkConfig.label,
+        expiresAt: new Date(Number(validBefore) * 1000).toISOString(),
+      })
+    );
+    return;
+  }
+
+  // Human output
+  const resourceUrl = (resource.url ?? 'https://mcp.apify.com/mcp').replace(/\?.*$/, '');
+
+  console.log(formatSuccess('Payment signed'));
+  console.log(formatInfo(`Wallet    : ${chalk.bold(name)} (${account.address})`));
+  console.log(formatInfo(`Network   : ${networkConfig.label}`));
+  console.log(formatInfo(`To        : ${accept.payTo}`));
+  console.log(
+    formatInfo(
+      `Amount    : $${amountUsd.toFixed(2)} (${amountAtomicUnits.toString()} atomic units)`
+    )
+  );
+  console.log(formatInfo(`Expires   : ${new Date(Number(validBefore) * 1000).toISOString()}`));
+  console.log('');
+  console.log(chalk.bold('  PAYMENT-SIGNATURE header:'));
+  console.log(`  ${payloadBase64}`);
+  console.log('');
+  console.log(chalk.bold('  MCP config snippet:'));
+  console.log(
+    JSON.stringify(
+      {
+        mcp: {
+          'apify-x402': {
+            type: 'remote',
+            url: `${resourceUrl}?payment=x402`,
+            headers: { 'PAYMENT-SIGNATURE': payloadBase64 },
+          },
+        },
+      },
+      null,
+      2
+    )
+      .split('\n')
+      .map((l) => `  ${l}`)
+      .join('\n')
+  );
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Top-level x402 command router
+// ---------------------------------------------------------------------------
+
+export async function handleX402Command(args: string[]): Promise<void> {
+  const program = new Command();
+  program.name('mcpc x402').description('x402 wallet management and payment signing');
+
+  // Inherit global options so they parse correctly
+  program.option('-j, --json', 'Output in JSON format').option('--verbose', 'Enable debug logging');
+
+  const resolveOutputMode = (cmd: Command): OutputMode => {
+    const opts = cmd.optsWithGlobals();
+    return opts.json ? 'json' : 'human';
+  };
+
+  program
+    .command('init')
+    .description('Create a new x402 wallet')
+    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
+    .action(async (opts, cmd) => {
+      await initWallet({ name: opts.name, outputMode: resolveOutputMode(cmd) });
+    });
+
+  program
+    .command('import <private-key>')
+    .description('Import an existing wallet from a private key')
+    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
+    .action(async (privateKey, opts, cmd) => {
+      await importWallet({ name: opts.name, privateKey, outputMode: resolveOutputMode(cmd) });
+    });
+
+  program
+    .command('list')
+    .description('List saved wallets')
+    .action(async (_opts, cmd) => {
+      await listWallets({ outputMode: resolveOutputMode(cmd) });
+    });
+
+  program
+    .command('remove')
+    .description('Remove a saved wallet')
+    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
+    .action(async (opts, cmd) => {
+      await removeWalletCmd({ name: opts.name, outputMode: resolveOutputMode(cmd) });
+    });
+
+  program
+    .command('sign')
+    .description('Sign a payment using a saved wallet')
+    .requiredOption(
+      '-r, --payment-required <base64>',
+      'PAYMENT-REQUIRED header from a 402 response'
+    )
+    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
+    .option('--amount <usd>', 'Override amount in USD')
+    .option('--expiry <seconds>', 'Override expiry in seconds')
+    .action(async (opts, cmd) => {
+      await signPayment({
+        name: opts.name,
+        paymentRequired: opts.paymentRequired,
+        amount: opts.amount,
+        expiry: opts.expiry,
+        outputMode: resolveOutputMode(cmd),
+      });
+    });
+
+  // Show help if no subcommand
+  if (args.length === 0) {
+    program.outputHelp();
+    return;
+  }
+
+  try {
+    await program.parseAsync(['node', 'mcpc-x402', ...args]);
+  } catch (error) {
+    if (error instanceof ClientError) {
+      console.error(formatError(error.message));
+      process.exit(1);
+    }
+    throw error;
+  }
+}

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -7,13 +7,7 @@ import chalk from 'chalk';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import type { Hex } from 'viem';
 import { formatSuccess, formatError, formatInfo, formatJson } from '../output.js';
-import {
-  loadWallets,
-  getWallet,
-  saveWallet,
-  removeWallet,
-  resolveWalletName,
-} from '../../lib/wallets.js';
+import { getWallet, saveWallet, removeWallet } from '../../lib/wallets.js';
 import { ClientError } from '../../lib/errors.js';
 import type { OutputMode } from '../../lib/types.js';
 import { signPayment, parsePaymentRequired } from '../../lib/x402/signer.js';
@@ -22,20 +16,17 @@ import { signPayment, parsePaymentRequired } from '../../lib/x402/signer.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_WALLET_NAME = 'default';
 const USDC_DECIMALS = 6;
 
 // ---------------------------------------------------------------------------
 // Command: init
 // ---------------------------------------------------------------------------
 
-async function initWallet(options: { name?: string; outputMode: OutputMode }): Promise<void> {
-  const name = resolveWalletName(options.name);
-
-  const existing = await getWallet(name);
+async function initWallet(options: { outputMode: OutputMode }): Promise<void> {
+  const existing = await getWallet();
   if (existing) {
     throw new ClientError(
-      `Wallet "${name}" already exists (address: ${existing.address}). Use "mcpc x402 remove --name ${name}" first.`
+      `Wallet already exists (address: ${existing.address}). Use "mcpc x402 remove" first.`
     );
   }
 
@@ -43,16 +34,15 @@ async function initWallet(options: { name?: string; outputMode: OutputMode }): P
   const account = privateKeyToAccount(privateKey);
 
   await saveWallet({
-    name,
     address: account.address,
     privateKey,
     createdAt: new Date().toISOString(),
   });
 
   if (options.outputMode === 'json') {
-    console.log(formatJson({ name, address: account.address }));
+    console.log(formatJson({ address: account.address }));
   } else {
-    console.log(formatSuccess(`Wallet "${name}" created`));
+    console.log(formatSuccess('Wallet created'));
     console.log(formatInfo(`Address: ${chalk.cyan(account.address)}`));
     console.log(formatInfo('Fund this address with USDC on Base to use x402 payments.'));
   }
@@ -63,16 +53,13 @@ async function initWallet(options: { name?: string; outputMode: OutputMode }): P
 // ---------------------------------------------------------------------------
 
 async function importWallet(options: {
-  name?: string;
   privateKey: string;
   outputMode: OutputMode;
 }): Promise<void> {
-  const name = resolveWalletName(options.name);
-
-  const existing = await getWallet(name);
+  const existing = await getWallet();
   if (existing) {
     throw new ClientError(
-      `Wallet "${name}" already exists (address: ${existing.address}). Use "mcpc x402 remove --name ${name}" first.`
+      `Wallet already exists (address: ${existing.address}). Use "mcpc x402 remove" first.`
     );
   }
 
@@ -89,62 +76,56 @@ async function importWallet(options: {
   }
 
   await saveWallet({
-    name,
     address: account.address,
     privateKey: key,
     createdAt: new Date().toISOString(),
   });
 
   if (options.outputMode === 'json') {
-    console.log(formatJson({ name, address: account.address }));
+    console.log(formatJson({ address: account.address }));
   } else {
-    console.log(formatSuccess(`Wallet "${name}" imported`));
+    console.log(formatSuccess('Wallet imported'));
     console.log(formatInfo(`Address: ${chalk.cyan(account.address)}`));
   }
 }
 
 // ---------------------------------------------------------------------------
-// Command: list
+// Command: info
 // ---------------------------------------------------------------------------
 
-async function listWallets(options: { outputMode: OutputMode }): Promise<void> {
-  const storage = await loadWallets();
-  const wallets = Object.values(storage.wallets);
+async function walletInfo(options: { outputMode: OutputMode }): Promise<void> {
+  const wallet = await getWallet();
 
   if (options.outputMode === 'json') {
     console.log(
-      formatJson(wallets.map((w) => ({ name: w.name, address: w.address, createdAt: w.createdAt })))
+      formatJson(wallet ? { address: wallet.address, createdAt: wallet.createdAt } : null)
     );
     return;
   }
 
-  if (wallets.length === 0) {
-    console.log(formatInfo('No wallets found. Create one with: mcpc x402 init'));
+  if (!wallet) {
+    console.log(formatInfo('No wallet configured. Create one with: mcpc x402 init'));
     return;
   }
 
-  for (const w of wallets) {
-    const isDefault = w.name === DEFAULT_WALLET_NAME ? chalk.dim(' (default)') : '';
-    console.log(`  ${chalk.bold(w.name)}${isDefault}  ${chalk.cyan(w.address)}`);
-  }
+  console.log(`  ${chalk.bold('Address')}   ${chalk.cyan(wallet.address)}`);
+  console.log(`  ${chalk.bold('Created')}   ${wallet.createdAt}`);
 }
 
 // ---------------------------------------------------------------------------
 // Command: remove
 // ---------------------------------------------------------------------------
 
-async function removeWalletCmd(options: { name?: string; outputMode: OutputMode }): Promise<void> {
-  const name = resolveWalletName(options.name);
-
-  const removed = await removeWallet(name);
+async function removeWalletCmd(options: { outputMode: OutputMode }): Promise<void> {
+  const removed = await removeWallet();
   if (!removed) {
-    throw new ClientError(`Wallet "${name}" not found.`);
+    throw new ClientError('No wallet configured.');
   }
 
   if (options.outputMode === 'json') {
-    console.log(formatJson({ name, removed: true }));
+    console.log(formatJson({ removed: true }));
   } else {
-    console.log(formatSuccess(`Wallet "${name}" removed.`));
+    console.log(formatSuccess('Wallet removed.'));
   }
 }
 
@@ -153,7 +134,6 @@ async function removeWalletCmd(options: { name?: string; outputMode: OutputMode 
 // ---------------------------------------------------------------------------
 
 interface SignOptions {
-  name?: string;
   paymentRequired: string;
   amount?: string;
   expiry?: string;
@@ -161,13 +141,9 @@ interface SignOptions {
 }
 
 async function signPaymentCommand(options: SignOptions): Promise<void> {
-  const name = resolveWalletName(options.name);
-
-  const wallet = await getWallet(name);
+  const wallet = await getWallet();
   if (!wallet) {
-    throw new ClientError(
-      `Wallet "${name}" not found. Create one with: mcpc x402 init --name ${name}`
-    );
+    throw new ClientError('No wallet configured. Create one with: mcpc x402 init');
   }
 
   // Parse PAYMENT-REQUIRED header
@@ -212,7 +188,7 @@ async function signPaymentCommand(options: SignOptions): Promise<void> {
   const resourceUrl = (header.resource?.url ?? 'https://mcp.apify.com/mcp').replace(/\?.*$/, '');
 
   console.log(formatSuccess('Payment signed'));
-  console.log(formatInfo(`Wallet    : ${chalk.bold(name)} (${result.from})`));
+  console.log(formatInfo(`Wallet    : ${result.from}`));
   console.log(formatInfo(`Network   : ${result.networkLabel}`));
   console.log(formatInfo(`To        : ${result.to}`));
   console.log(
@@ -266,47 +242,42 @@ export async function handleX402Command(args: string[]): Promise<void> {
   program
     .command('init')
     .description('Create a new x402 wallet')
-    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
-    .action(async (opts, cmd) => {
-      await initWallet({ name: opts.name, outputMode: resolveOutputMode(cmd) });
+    .action(async (_opts, cmd) => {
+      await initWallet({ outputMode: resolveOutputMode(cmd) });
     });
 
   program
     .command('import <private-key>')
     .description('Import an existing wallet from a private key')
-    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
-    .action(async (privateKey, opts, cmd) => {
-      await importWallet({ name: opts.name, privateKey, outputMode: resolveOutputMode(cmd) });
+    .action(async (privateKey, _opts, cmd) => {
+      await importWallet({ privateKey, outputMode: resolveOutputMode(cmd) });
     });
 
   program
-    .command('list')
-    .description('List saved wallets')
+    .command('info')
+    .description('Show wallet info')
     .action(async (_opts, cmd) => {
-      await listWallets({ outputMode: resolveOutputMode(cmd) });
+      await walletInfo({ outputMode: resolveOutputMode(cmd) });
     });
 
   program
     .command('remove')
-    .description('Remove a saved wallet')
-    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
-    .action(async (opts, cmd) => {
-      await removeWalletCmd({ name: opts.name, outputMode: resolveOutputMode(cmd) });
+    .description('Remove the wallet')
+    .action(async (_opts, cmd) => {
+      await removeWalletCmd({ outputMode: resolveOutputMode(cmd) });
     });
 
   program
     .command('sign')
-    .description('Sign a payment using a saved wallet')
+    .description('Sign a payment using the wallet')
     .requiredOption(
       '-r, --payment-required <base64>',
       'PAYMENT-REQUIRED header from a 402 response'
     )
-    .option('--name <name>', `Wallet name (default: "${DEFAULT_WALLET_NAME}")`)
     .option('--amount <usd>', 'Override amount in USD')
     .option('--expiry <seconds>', 'Override expiry in seconds')
     .action(async (opts, cmd) => {
       await signPaymentCommand({
-        name: opts.name,
         paymentRequired: opts.paymentRequired,
         amount: opts.amount,
         expiry: opts.expiry,

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -5,8 +5,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-import { createWalletClient, http, type Hex } from 'viem';
-import { base, baseSepolia } from 'viem/chains';
+import type { Hex } from 'viem';
 import { formatSuccess, formatError, formatInfo, formatJson } from '../output.js';
 import {
   loadWallets,
@@ -17,6 +16,7 @@ import {
 } from '../../lib/wallets.js';
 import { ClientError } from '../../lib/errors.js';
 import type { OutputMode } from '../../lib/types.js';
+import { signPayment, parsePaymentRequired } from '../../lib/x402/signer.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -24,108 +24,6 @@ import type { OutputMode } from '../../lib/types.js';
 
 const DEFAULT_WALLET_NAME = 'default';
 const USDC_DECIMALS = 6;
-const X402_VERSION = 2;
-
-const TRANSFER_WITH_AUTHORIZATION_TYPES = {
-  TransferWithAuthorization: [
-    { name: 'from', type: 'address' },
-    { name: 'to', type: 'address' },
-    { name: 'value', type: 'uint256' },
-    { name: 'validAfter', type: 'uint256' },
-    { name: 'validBefore', type: 'uint256' },
-    { name: 'nonce', type: 'bytes32' },
-  ],
-} as const;
-
-interface NetworkConfig {
-  chain: typeof base | typeof baseSepolia;
-  networkId: string;
-  rpcUrl: string;
-  label: string;
-}
-
-const NETWORKS: Record<string, NetworkConfig> = {
-  [`eip155:${base.id}`]: {
-    chain: base,
-    networkId: `eip155:${base.id}`,
-    rpcUrl: 'https://mainnet.base.org',
-    label: 'Base Mainnet',
-  },
-  [`eip155:${baseSepolia.id}`]: {
-    chain: baseSepolia,
-    networkId: `eip155:${baseSepolia.id}`,
-    rpcUrl: 'https://sepolia.base.org',
-    label: 'Base Sepolia (testnet)',
-  },
-};
-
-// ---------------------------------------------------------------------------
-// PAYMENT-REQUIRED header parsing
-// ---------------------------------------------------------------------------
-
-interface PaymentRequiredAccept {
-  scheme: string;
-  network: string;
-  amount: string;
-  asset: string;
-  payTo: string;
-  maxTimeoutSeconds: number;
-  extra?: { name?: string; version?: string };
-}
-
-interface PaymentRequiredHeader {
-  x402Version: number;
-  resource?: { url?: string; description?: string; mimeType?: string };
-  accepts: PaymentRequiredAccept[];
-}
-
-function parsePaymentRequired(base64Value: string): {
-  header: PaymentRequiredHeader;
-  accept: PaymentRequiredAccept;
-} {
-  let decoded: string;
-  try {
-    decoded = Buffer.from(base64Value, 'base64').toString('utf-8');
-  } catch {
-    throw new ClientError('Failed to base64-decode the --payment-required value.');
-  }
-
-  let header: PaymentRequiredHeader;
-  try {
-    header = JSON.parse(decoded) as PaymentRequiredHeader;
-  } catch {
-    throw new ClientError('PAYMENT-REQUIRED header is not valid JSON after base64 decoding.');
-  }
-
-  if (!header.accepts || !Array.isArray(header.accepts) || header.accepts.length === 0) {
-    throw new ClientError('PAYMENT-REQUIRED header has no "accepts" entries.');
-  }
-
-  const accept = header.accepts.find((a) => a.scheme === 'exact');
-  if (!accept) {
-    throw new ClientError(
-      `No "exact" scheme found in PAYMENT-REQUIRED accepts. Available: ${header.accepts.map((a) => a.scheme).join(', ')}`
-    );
-  }
-
-  if (!accept.payTo || !accept.amount || !accept.network || !accept.asset) {
-    throw new ClientError(
-      'PAYMENT-REQUIRED accept entry is missing required fields (payTo, amount, network, asset).'
-    );
-  }
-
-  return { header, accept };
-}
-
-// ---------------------------------------------------------------------------
-// Crypto helpers
-// ---------------------------------------------------------------------------
-
-function randomBytes32(): Hex {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  return ('0x' + [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')) as Hex;
-}
 
 // ---------------------------------------------------------------------------
 // Command: init
@@ -262,7 +160,7 @@ interface SignOptions {
   outputMode: OutputMode;
 }
 
-async function signPayment(options: SignOptions): Promise<void> {
+async function signPaymentCommand(options: SignOptions): Promise<void> {
   const name = resolveWalletName(options.name);
 
   const wallet = await getWallet(name);
@@ -275,132 +173,57 @@ async function signPayment(options: SignOptions): Promise<void> {
   // Parse PAYMENT-REQUIRED header
   const { header, accept } = parsePaymentRequired(options.paymentRequired);
 
-  // Resolve network
-  const networkConfig = NETWORKS[accept.network];
-  if (!networkConfig) {
-    throw new ClientError(
-      `Unknown network "${accept.network}" in PAYMENT-REQUIRED. Supported: ${Object.keys(NETWORKS).join(', ')}`
-    );
-  }
-
-  // Resolve amount (CLI override or from header)
-  let amountAtomicUnits: bigint;
-  let amountUsd: number;
+  // Resolve overrides
+  let amountOverride: bigint | undefined;
   if (options.amount) {
-    amountUsd = parseFloat(options.amount);
+    const amountUsd = parseFloat(options.amount);
     if (isNaN(amountUsd) || amountUsd <= 0)
       throw new ClientError('--amount must be a positive number.');
-    amountAtomicUnits = BigInt(Math.round(amountUsd * 10 ** USDC_DECIMALS));
-  } else {
-    amountAtomicUnits = BigInt(accept.amount);
-    amountUsd = Number(amountAtomicUnits) / 10 ** USDC_DECIMALS;
+    amountOverride = BigInt(Math.round(amountUsd * 10 ** USDC_DECIMALS));
   }
 
-  // Resolve expiry
-  const expirySeconds = options.expiry
-    ? parseInt(options.expiry, 10)
-    : accept.maxTimeoutSeconds || 3600;
+  const expiryOverride = options.expiry ? parseInt(options.expiry, 10) : undefined;
 
-  // EIP-3009 domain from header extra or defaults
-  const eip3009Name = accept.extra?.name ?? 'USDC';
-  const eip3009Version = accept.extra?.version ?? '2';
-
-  // Resource from header
-  const resource = header.resource ?? {
-    url: 'https://mcp.apify.com/mcp',
-    description: 'MCP Server',
-    mimeType: 'application/json',
-  };
-
-  // Sign
-  const account = privateKeyToAccount(wallet.privateKey as Hex);
-  const walletClient = createWalletClient({
-    account,
-    chain: networkConfig.chain,
-    transport: http(networkConfig.rpcUrl),
+  // Sign using shared signer
+  const result = await signPayment({
+    wallet: { privateKey: wallet.privateKey, address: wallet.address },
+    accept,
+    resource: header.resource,
+    ...(amountOverride !== undefined && { amountOverride }),
+    ...(expiryOverride !== undefined && { expiryOverride }),
   });
-
-  const nonce = randomBytes32();
-  const validBefore = BigInt(Math.floor(Date.now() / 1000) + expirySeconds);
-
-  const signature = await walletClient.signTypedData({
-    domain: {
-      name: eip3009Name,
-      version: eip3009Version,
-      chainId: networkConfig.chain.id,
-      verifyingContract: accept.asset as Hex,
-    },
-    types: TRANSFER_WITH_AUTHORIZATION_TYPES,
-    primaryType: 'TransferWithAuthorization',
-    message: {
-      from: account.address,
-      to: accept.payTo as Hex,
-      value: amountAtomicUnits,
-      validAfter: 0n,
-      validBefore,
-      nonce,
-    },
-  });
-
-  // Build x402 payload
-  const paymentPayload = {
-    x402Version: X402_VERSION,
-    resource,
-    payload: {
-      signature,
-      authorization: {
-        from: account.address,
-        to: accept.payTo,
-        value: amountAtomicUnits.toString(),
-        validAfter: '0',
-        validBefore: validBefore.toString(),
-        nonce,
-      },
-    },
-    accepted: {
-      scheme: 'exact',
-      network: networkConfig.networkId,
-      asset: accept.asset,
-      amount: amountAtomicUnits.toString(),
-      payTo: accept.payTo,
-      maxTimeoutSeconds: expirySeconds,
-      extra: { name: eip3009Name, version: eip3009Version },
-    },
-  };
-
-  const payloadBase64 = Buffer.from(JSON.stringify(paymentPayload)).toString('base64');
 
   if (options.outputMode === 'json') {
     console.log(
       formatJson({
-        paymentSignature: payloadBase64,
-        from: account.address,
-        to: accept.payTo,
-        amount: amountUsd,
-        amountAtomicUnits: amountAtomicUnits.toString(),
-        network: networkConfig.label,
-        expiresAt: new Date(Number(validBefore) * 1000).toISOString(),
+        paymentSignature: result.paymentSignatureBase64,
+        from: result.from,
+        to: result.to,
+        amount: result.amountUsd,
+        amountAtomicUnits: result.amountAtomicUnits.toString(),
+        network: result.networkLabel,
+        expiresAt: result.expiresAt.toISOString(),
       })
     );
     return;
   }
 
   // Human output
-  const resourceUrl = (resource.url ?? 'https://mcp.apify.com/mcp').replace(/\?.*$/, '');
+  const resourceUrl = (header.resource?.url ?? 'https://mcp.apify.com/mcp').replace(/\?.*$/, '');
 
   console.log(formatSuccess('Payment signed'));
-  console.log(formatInfo(`Wallet    : ${chalk.bold(name)} (${account.address})`));
-  console.log(formatInfo(`Network   : ${networkConfig.label}`));
-  console.log(formatInfo(`To        : ${accept.payTo}`));
+  console.log(formatInfo(`Wallet    : ${chalk.bold(name)} (${result.from})`));
+  console.log(formatInfo(`Network   : ${result.networkLabel}`));
+  console.log(formatInfo(`To        : ${result.to}`));
   console.log(
     formatInfo(
-      `Amount    : $${amountUsd.toFixed(2)} (${amountAtomicUnits.toString()} atomic units)`
+      `Amount    : $${result.amountUsd.toFixed(2)} (${result.amountAtomicUnits.toString()} atomic units)`
     )
   );
-  console.log(formatInfo(`Expires   : ${new Date(Number(validBefore) * 1000).toISOString()}`));
+  console.log(formatInfo(`Expires   : ${result.expiresAt.toISOString()}`));
   console.log('');
   console.log(chalk.bold('  PAYMENT-SIGNATURE header:'));
-  console.log(`  ${payloadBase64}`);
+  console.log(`  ${result.paymentSignatureBase64}`);
   console.log('');
   console.log(chalk.bold('  MCP config snippet:'));
   console.log(
@@ -410,7 +233,7 @@ async function signPayment(options: SignOptions): Promise<void> {
           'apify-x402': {
             type: 'remote',
             url: `${resourceUrl}?payment=x402`,
-            headers: { 'PAYMENT-SIGNATURE': payloadBase64 },
+            headers: { 'PAYMENT-SIGNATURE': result.paymentSignatureBase64 },
           },
         },
       },
@@ -482,7 +305,7 @@ export async function handleX402Command(args: string[]): Promise<void> {
     .option('--amount <usd>', 'Override amount in USD')
     .option('--expiry <seconds>', 'Override expiry in seconds')
     .action(async (opts, cmd) => {
-      await signPayment({
+      await signPaymentCommand({
         name: opts.name,
         paymentRequired: opts.paymentRequired,
         amount: opts.amount,

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -21,6 +21,8 @@ import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
 import { getAuthProfile, listAuthProfiles } from '../lib/auth/profiles.js';
 import { readKeychainOAuthTokenInfo, readKeychainOAuthClientInfo } from '../lib/auth/keychain.js';
 import { logTarget } from './output.js';
+import { getWallet, resolveWalletName } from '../lib/wallets.js';
+import { createX402FetchMiddleware } from '../lib/x402/fetch-middleware.js';
 import { createRequire } from 'module';
 const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.json') as {
   version: string;
@@ -256,6 +258,7 @@ export async function withMcpClient<T>(
     verbose?: boolean;
     hideTarget?: boolean;
     profile?: string;
+    x402?: string;
   },
   callback: (client: IMcpClient, context: McpClientContext) => Promise<T>
 ): Promise<T> {
@@ -318,6 +321,24 @@ export async function withMcpClient<T>(
     if (authProvider) {
       clientConfig.authProvider = authProvider;
       logger.debug(`Using auth profile: ${profileName}`);
+    }
+
+    // Set up x402 fetch middleware for automatic payment signing
+    if (options.x402) {
+      const walletName = resolveWalletName(options.x402);
+      const wallet = await getWallet(walletName);
+      if (!wallet) {
+        throw new ClientError(
+          `x402 wallet "${walletName}" not found. Create one with: mcpc x402 init --name ${walletName}`
+        );
+      }
+      logger.debug(`Using x402 wallet: ${walletName} (${wallet.address})`);
+      clientConfig.customFetch = createX402FetchMiddleware(fetch, {
+        wallet: { privateKey: wallet.privateKey, address: wallet.address },
+        // No getToolByName for direct connections — proactive signing requires
+        // a tools list cache which direct connections don't maintain.
+        // The 402 fallback will still work.
+      });
     }
   }
 

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -21,7 +21,7 @@ import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
 import { getAuthProfile, listAuthProfiles } from '../lib/auth/profiles.js';
 import { readKeychainOAuthTokenInfo, readKeychainOAuthClientInfo } from '../lib/auth/keychain.js';
 import { logTarget } from './output.js';
-import { getWallet, resolveWalletName } from '../lib/wallets.js';
+import { getWallet } from '../lib/wallets.js';
 import { createX402FetchMiddleware } from '../lib/x402/fetch-middleware.js';
 import { createRequire } from 'module';
 const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.json') as {
@@ -258,7 +258,7 @@ export async function withMcpClient<T>(
     verbose?: boolean;
     hideTarget?: boolean;
     profile?: string;
-    x402?: string;
+    x402?: boolean;
   },
   callback: (client: IMcpClient, context: McpClientContext) => Promise<T>
 ): Promise<T> {
@@ -325,14 +325,11 @@ export async function withMcpClient<T>(
 
     // Set up x402 fetch middleware for automatic payment signing
     if (options.x402) {
-      const walletName = resolveWalletName(options.x402);
-      const wallet = await getWallet(walletName);
+      const wallet = await getWallet();
       if (!wallet) {
-        throw new ClientError(
-          `x402 wallet "${walletName}" not found. Create one with: mcpc x402 init --name ${walletName}`
-        );
+        throw new ClientError('x402 wallet not found. Create one with: mcpc x402 init');
       }
-      logger.debug(`Using x402 wallet: ${walletName} (${wallet.address})`);
+      logger.debug(`Using x402 wallet: ${wallet.address}`);
       clientConfig.customFetch = createX402FetchMiddleware(fetch, {
         wallet: { privateKey: wallet.privateKey, address: wallet.address },
         // No getToolByName for direct connections — proactive signing requires

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import * as sessions from './commands/sessions.js';
 import * as logging from './commands/logging.js';
 import * as utilities from './commands/utilities.js';
 import * as auth from './commands/auth.js';
+import { handleX402Command } from './commands/x402.js';
 import { clean } from './commands/clean.js';
 import type { OutputMode } from '../lib/index.js';
 import {
@@ -202,6 +203,14 @@ async function main(): Promise<void> {
     ...args.slice(0, targetIndex),
     ...args.slice(targetIndex + 1),
   ];
+
+  // Handle x402 as a top-level command (not a server target)
+  if (target === 'x402') {
+    const x402Args = args.slice(targetIndex + 1);
+    await handleX402Command(x402Args);
+    await closeFileLogger();
+    return;
+  }
 
   // Handle commands
   try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -320,6 +320,13 @@ MCP server commands:
   resources-templates-list
   logging-set-level <level>
   ping
+
+x402 payment commands (no target needed):
+  x402 init [--name <name>]     Create a new x402 wallet
+  x402 import <key> [--name]    Import wallet from private key
+  x402 sign -r <base64>         Sign payment from PAYMENT-REQUIRED header
+  x402 list                     List saved wallets
+  x402 remove [--name <name>]   Remove a wallet
   
 Run "mcpc" without <target> to show available sessions and profiles.
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,6 +54,7 @@ interface HandlerOptions {
   timeout?: number;
   verbose?: boolean;
   profile?: string;
+  x402?: string;
   schema?: string;
   schemaMode?: 'strict' | 'compatible' | 'ignore';
   full?: boolean;
@@ -89,6 +90,7 @@ function getOptionsFromCommand(command: Command): HandlerOptions {
   if (opts.timeout) options.timeout = parseInt(opts.timeout, 10);
   if (opts.profile) options.profile = opts.profile;
   if (verbose) options.verbose = verbose;
+  if (opts.x402) options.x402 = 'default';
   if (opts.schema) options.schema = opts.schema;
   if (opts.schemaMode) {
     const mode = opts.schemaMode as string;
@@ -281,6 +283,7 @@ function createProgram(): Command {
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 300)')
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session (with "connect" command)')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
+    .option('--x402', 'Enable x402 auto-payment using the default wallet')
     .option('--clean[=types]', 'Clean up mcpc data (types: sessions, logs, profiles, all)');
 
   // Add help text to match README
@@ -399,6 +402,7 @@ async function handleCommands(target: string, args: string[]): Promise<void> {
         ...getOptionsFromCommand(command),
         proxy: opts.proxy,
         proxyBearerToken: opts.proxyBearerToken,
+        x402: opts.x402,
       });
     });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,7 +54,7 @@ interface HandlerOptions {
   timeout?: number;
   verbose?: boolean;
   profile?: string;
-  x402?: string;
+  x402?: boolean;
   schema?: string;
   schemaMode?: 'strict' | 'compatible' | 'ignore';
   full?: boolean;
@@ -90,7 +90,7 @@ function getOptionsFromCommand(command: Command): HandlerOptions {
   if (opts.timeout) options.timeout = parseInt(opts.timeout, 10);
   if (opts.profile) options.profile = opts.profile;
   if (verbose) options.verbose = verbose;
-  if (opts.x402) options.x402 = 'default';
+  if (opts.x402) options.x402 = true;
   if (opts.schema) options.schema = opts.schema;
   if (opts.schemaMode) {
     const mode = opts.schemaMode as string;
@@ -283,7 +283,7 @@ function createProgram(): Command {
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 300)')
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session (with "connect" command)')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
-    .option('--x402', 'Enable x402 auto-payment using the default wallet')
+    .option('--x402', 'Enable x402 auto-payment using the configured wallet')
     .option('--clean[=types]', 'Clean up mcpc data (types: sessions, logs, profiles, all)');
 
   // Add help text to match README
@@ -325,11 +325,11 @@ MCP server commands:
   ping
 
 x402 payment commands (no target needed):
-  x402 init [--name <name>]     Create a new x402 wallet
-  x402 import <key> [--name]    Import wallet from private key
+  x402 init                     Create a new x402 wallet
+  x402 import <key>             Import wallet from private key
+  x402 info                     Show wallet info
   x402 sign -r <base64>         Sign payment from PAYMENT-REQUIRED header
-  x402 list                     List saved wallets
-  x402 remove [--name <name>]   Remove a wallet
+  x402 remove                   Remove the wallet
   
 Run "mcpc" without <target> to show available sessions and profiles.
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -87,6 +87,7 @@ export const KNOWN_COMMANDS = [
   'prompts-get',
   'logging-set-level',
   'ping',
+  'x402',
 ];
 
 // Valid --schema-mode values

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -56,6 +56,7 @@ const KNOWN_OPTIONS = [
   '--verbose',
   '--clean',
   '--full',
+  '--x402',
 ];
 
 // Valid --clean types
@@ -94,7 +95,7 @@ export const KNOWN_COMMANDS = [
 const VALID_SCHEMA_MODES = ['strict', 'compatible', 'ignore'];
 
 /**
- * Check if an option takes a value
+ * Check if an option always takes a value
  */
 export function optionTakesValue(arg: string): boolean {
   const optionName = arg.includes('=') ? arg.substring(0, arg.indexOf('=')) : arg;
@@ -236,6 +237,7 @@ export function extractOptions(args: string[]): {
   headers?: string[];
   timeout?: number;
   profile?: string;
+  x402?: string;
   verbose: boolean;
   json: boolean;
 } {
@@ -270,12 +272,16 @@ export function extractOptions(args: string[]): {
   const profile =
     profileIndex >= 0 && profileIndex + 1 < args.length ? args[profileIndex + 1] : undefined;
 
+  // Extract --x402 (boolean flag — always uses the default wallet)
+  const x402 = args.includes('--x402') ? 'default' : undefined;
+
   return {
     ...options,
     ...(config && { config }),
     ...(headers.length > 0 && { headers }),
     ...(timeout !== undefined && { timeout }),
     ...(profile && { profile }),
+    ...(x402 && { x402 }),
   };
 }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -237,7 +237,7 @@ export function extractOptions(args: string[]): {
   headers?: string[];
   timeout?: number;
   profile?: string;
-  x402?: string;
+  x402?: boolean;
   verbose: boolean;
   json: boolean;
 } {
@@ -272,8 +272,8 @@ export function extractOptions(args: string[]): {
   const profile =
     profileIndex >= 0 && profileIndex + 1 < args.length ? args[profileIndex + 1] : undefined;
 
-  // Extract --x402 (boolean flag — always uses the default wallet)
-  const x402 = args.includes('--x402') ? 'default' : undefined;
+  // Extract --x402 (boolean flag)
+  const x402 = args.includes('--x402') || undefined;
 
   return {
     ...options,

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -4,6 +4,7 @@
 
 import type { ClientCapabilities, ListChangedHandlers } from '@modelcontextprotocol/sdk/types.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { McpClient, type McpClientOptions } from './mcp-client.js';
 import { createTransportFromConfig } from './transports.js';
 import { type ServerConfig } from '../lib/types.js';
@@ -50,6 +51,12 @@ export interface CreateMcpClientOptions {
    * MCP-Session-Id for resuming a previous session (HTTP transport only)
    */
   mcpSessionId?: string;
+
+  /**
+   * Custom fetch function for the transport (HTTP transport only)
+   * Used by x402 payment middleware
+   */
+  customFetch?: FetchLike;
 
   /**
    * Whether to automatically connect after creation
@@ -120,12 +127,20 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
   if (autoConnect) {
     factoryLogger.debug('Creating transport with authProvider:', !!options.authProvider);
     factoryLogger.debug('Creating transport with mcpSessionId:', options.mcpSessionId || '(none)');
-    const transportOptions: { authProvider?: OAuthClientProvider; mcpSessionId?: string } = {};
+    factoryLogger.debug('Creating transport with customFetch:', !!options.customFetch);
+    const transportOptions: {
+      authProvider?: OAuthClientProvider;
+      mcpSessionId?: string;
+      customFetch?: FetchLike;
+    } = {};
     if (options.authProvider) {
       transportOptions.authProvider = options.authProvider;
     }
     if (options.mcpSessionId) {
       transportOptions.mcpSessionId = options.mcpSessionId;
+    }
+    if (options.customFetch) {
+      transportOptions.customFetch = options.customFetch;
     }
     const transport = createTransportFromConfig(options.serverConfig, transportOptions);
     await client.connect(transport);

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -26,7 +26,7 @@ export {
 // Re-export auth-related types if needed
 export type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { Transport, FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 import {
   StdioClientTransport,
@@ -62,7 +62,7 @@ export function createStdioTransport(config: StdioServerParameters): Transport {
  */
 export function createStreamableHttpTransport(
   url: string,
-  options: Omit<StreamableHTTPClientTransportOptions, 'fetch'> = {}
+  options: StreamableHTTPClientTransportOptions = {}
 ): Transport {
   const logger = createLogger('StreamableHttpTransport');
   logger.debug('Creating Streamable HTTP transport', { url });
@@ -119,6 +119,12 @@ export interface CreateTransportOptions {
    * If provided, the transport will include this in the MCP-Session-Id header
    */
   mcpSessionId?: string;
+
+  /**
+   * Custom fetch function (HTTP transport only)
+   * Used by x402 middleware to intercept and modify requests
+   */
+  customFetch?: FetchLike;
 }
 
 /**
@@ -178,6 +184,12 @@ export function createTransportFromConfig(
         ...transportOptions.requestInit,
         signal: AbortSignal.timeout(config.timeout * 1000),
       };
+    }
+
+    // Set custom fetch function (e.g., x402 payment middleware)
+    if (options.customFetch) {
+      transportOptions.fetch = options.customFetch;
+      logger.debug('Setting custom fetch function on transport');
     }
 
     return createStreamableHttpTransport(config.url, transportOptions);

--- a/src/lib/auth/profiles.ts
+++ b/src/lib/auth/profiles.ts
@@ -62,7 +62,6 @@ async function saveAuthProfilesInternal(storage: AuthProfilesStorage): Promise<v
   // Ensure the directory exists
   await ensureDir(getMcpcHome());
 
-  // Write to a temp file first (atomic operation)
   // Write temp file in the same directory as the target to avoid EXDEV on Linux
   // (rename() fails across filesystem boundaries, e.g. /tmp vs ~/.mcpc)
   const tempFile = join(getMcpcHome(), `.profiles-${Date.now()}-${process.pid}.tmp`);

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -15,7 +15,7 @@
 
 import { connect, type Socket } from 'net';
 import { EventEmitter } from 'events';
-import type { IpcMessage, NotificationData } from './types.js';
+import type { IpcMessage, NotificationData, X402WalletCredentials } from './types.js';
 import { createLogger } from './logger.js';
 import { NetworkError, ClientError, ServerError, AuthError } from './errors.js';
 import { generateRequestId } from './utils.js';
@@ -244,6 +244,16 @@ export class BridgeClient extends EventEmitter {
     this.send({
       type: 'set-auth-credentials',
       authCredentials: credentials,
+    });
+  }
+
+  /**
+   * Send x402 wallet credentials to bridge (one-way, no response expected)
+   */
+  sendX402Wallet(wallet: X402WalletCredentials): void {
+    this.send({
+      type: 'set-x402-wallet',
+      x402Wallet: wallet,
     });
   }
 

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -33,7 +33,7 @@ import {
   readKeychainSessionHeaders,
 } from './auth/keychain.js';
 import { getAuthProfile } from './auth/profiles.js';
-import { getWallet, resolveWalletName } from './wallets.js';
+import { getWallet } from './wallets.js';
 
 const logger = createLogger('bridge-manager');
 
@@ -56,7 +56,7 @@ export interface StartBridgeOptions {
   headers?: Record<string, string>; // Headers to send via IPC (caller stores in keychain)
   proxyConfig?: ProxyConfig; // Proxy server configuration
   mcpSessionId?: string; // MCP session ID for resumption (Streamable HTTP only)
-  walletName?: string; // x402 wallet name for automatic payment signing
+  x402?: boolean; // Enable x402 auto-payment using the wallet
 }
 
 export interface StartBridgeResult {
@@ -87,7 +87,7 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     headers,
     proxyConfig,
     mcpSessionId,
-    walletName,
+    x402,
   } = options;
 
   logger.debug(`Launching bridge for session: ${sessionName}`);
@@ -138,10 +138,10 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     logger.debug(`Passing MCP session ID for resumption: ${mcpSessionId}`);
   }
 
-  // Pass x402 wallet name (if provided)
-  if (walletName) {
-    args.push('--wallet', walletName);
-    logger.debug(`Passing x402 wallet name: ${walletName}`);
+  // Pass x402 flag (if enabled)
+  if (x402) {
+    args.push('--x402');
+    logger.debug('Passing x402 flag to bridge');
   }
 
   logger.debug('Bridge executable:', bridgeExecutable);
@@ -191,8 +191,8 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
   }
 
   // Send x402 wallet credentials to bridge via IPC
-  if (walletName) {
-    await sendX402WalletToBridge(socketPath, walletName);
+  if (x402) {
+    await sendX402WalletToBridge(socketPath);
   }
 
   logger.debug(`Bridge started successfully for session: ${sessionName}`);
@@ -300,9 +300,9 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
     bridgeOptions.mcpSessionId = session.mcpSessionId;
     logger.debug(`Using saved MCP session ID for resumption: ${session.mcpSessionId}`);
   }
-  if (session.walletName) {
-    bridgeOptions.walletName = session.walletName;
-    logger.debug(`Using saved x402 wallet: ${session.walletName}`);
+  if (session.x402) {
+    bridgeOptions.x402 = session.x402;
+    logger.debug('Using saved x402 flag');
   }
 
   const { pid } = await startBridge(bridgeOptions);
@@ -391,22 +391,17 @@ async function sendAuthCredentialsToBridge(
  * Loads wallet data from wallets.json and sends it to bridge
  *
  * @param socketPath - Path to bridge's Unix socket
- * @param walletName - Name of the wallet in wallets.json
  */
-async function sendX402WalletToBridge(socketPath: string, walletName: string): Promise<void> {
-  const resolvedName = resolveWalletName(walletName);
-  const wallet = await getWallet(resolvedName);
+async function sendX402WalletToBridge(socketPath: string): Promise<void> {
+  const wallet = await getWallet();
 
   if (!wallet) {
-    throw new ClientError(
-      `x402 wallet "${resolvedName}" not found. Create one with: mcpc x402 init --name ${resolvedName}`
-    );
+    throw new ClientError('x402 wallet not found. Create one with: mcpc x402 init');
   }
 
-  logger.debug(`Sending x402 wallet "${resolvedName}" (${wallet.address}) to bridge`);
+  logger.debug(`Sending x402 wallet (${wallet.address}) to bridge`);
 
   const credentials: X402WalletCredentials = {
-    walletName: resolvedName,
     address: wallet.address,
     privateKey: wallet.privateKey,
   };

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -16,7 +16,7 @@ import { spawn, type ChildProcess } from 'child_process';
 import { unlink } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import type { ServerConfig, AuthCredentials, ProxyConfig } from './types.js';
+import type { ServerConfig, AuthCredentials, ProxyConfig, X402WalletCredentials } from './types.js';
 import { getSocketPath, waitForFile, isProcessAlive, fileExists, getLogsDir } from './utils.js';
 import { updateSession, getSession } from './sessions.js';
 import { createLogger } from './logger.js';
@@ -33,6 +33,7 @@ import {
   readKeychainSessionHeaders,
 } from './auth/keychain.js';
 import { getAuthProfile } from './auth/profiles.js';
+import { getWallet, resolveWalletName } from './wallets.js';
 
 const logger = createLogger('bridge-manager');
 
@@ -55,6 +56,7 @@ export interface StartBridgeOptions {
   headers?: Record<string, string>; // Headers to send via IPC (caller stores in keychain)
   proxyConfig?: ProxyConfig; // Proxy server configuration
   mcpSessionId?: string; // MCP session ID for resumption (Streamable HTTP only)
+  walletName?: string; // x402 wallet name for automatic payment signing
 }
 
 export interface StartBridgeResult {
@@ -77,8 +79,16 @@ export interface StartBridgeResult {
  * @returns Bridge process PID
  */
 export async function startBridge(options: StartBridgeOptions): Promise<StartBridgeResult> {
-  const { sessionName, serverConfig, verbose, profileName, headers, proxyConfig, mcpSessionId } =
-    options;
+  const {
+    sessionName,
+    serverConfig,
+    verbose,
+    profileName,
+    headers,
+    proxyConfig,
+    mcpSessionId,
+    walletName,
+  } = options;
 
   logger.debug(`Launching bridge for session: ${sessionName}`);
 
@@ -128,6 +138,12 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     logger.debug(`Passing MCP session ID for resumption: ${mcpSessionId}`);
   }
 
+  // Pass x402 wallet name (if provided)
+  if (walletName) {
+    args.push('--wallet', walletName);
+    logger.debug(`Passing x402 wallet name: ${walletName}`);
+  }
+
   logger.debug('Bridge executable:', bridgeExecutable);
   logger.debug('Bridge args:', args);
 
@@ -172,6 +188,11 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
       profileName,
       headers
     );
+  }
+
+  // Send x402 wallet credentials to bridge via IPC
+  if (walletName) {
+    await sendX402WalletToBridge(socketPath, walletName);
   }
 
   logger.debug(`Bridge started successfully for session: ${sessionName}`);
@@ -261,7 +282,7 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
     logger.debug(`Retrieved ${expectedHeaderKeys.length} headers from keychain for failover`);
   }
 
-  // Start a new bridge, preserving auth profile, proxy config, and MCP session ID
+  // Start a new bridge, preserving auth profile, proxy config, MCP session ID, and wallet
   const bridgeOptions: StartBridgeOptions = {
     sessionName,
     serverConfig: serverConfig,
@@ -278,6 +299,10 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
   if (session.mcpSessionId) {
     bridgeOptions.mcpSessionId = session.mcpSessionId;
     logger.debug(`Using saved MCP session ID for resumption: ${session.mcpSessionId}`);
+  }
+  if (session.walletName) {
+    bridgeOptions.walletName = session.walletName;
+    logger.debug(`Using saved x402 wallet: ${session.walletName}`);
   }
 
   const { pid } = await startBridge(bridgeOptions);
@@ -356,6 +381,41 @@ async function sendAuthCredentialsToBridge(
     await client.connect();
     client.sendAuthCredentials(credentials);
     logger.debug('Auth credentials sent to bridge successfully');
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Send x402 wallet credentials to a bridge process via IPC
+ * Loads wallet data from wallets.json and sends it to bridge
+ *
+ * @param socketPath - Path to bridge's Unix socket
+ * @param walletName - Name of the wallet in wallets.json
+ */
+async function sendX402WalletToBridge(socketPath: string, walletName: string): Promise<void> {
+  const resolvedName = resolveWalletName(walletName);
+  const wallet = await getWallet(resolvedName);
+
+  if (!wallet) {
+    throw new ClientError(
+      `x402 wallet "${resolvedName}" not found. Create one with: mcpc x402 init --name ${resolvedName}`
+    );
+  }
+
+  logger.debug(`Sending x402 wallet "${resolvedName}" (${wallet.address}) to bridge`);
+
+  const credentials: X402WalletCredentials = {
+    walletName: resolvedName,
+    address: wallet.address,
+    privateKey: wallet.privateKey,
+  };
+
+  const client = new BridgeClient(socketPath);
+  try {
+    await client.connect();
+    client.sendX402Wallet(credentials);
+    logger.debug('x402 wallet sent to bridge successfully');
   } finally {
     await client.close();
   }

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -60,7 +60,6 @@ async function saveSessionsInternal(storage: SessionsStorage): Promise<void> {
   // Ensure the directory exists
   await ensureDir(getMcpcHome());
 
-  // Write to a temp file first (atomic operation)
   // Write temp file in the same directory as the target to avoid EXDEV on Linux
   // (rename() fails across filesystem boundaries, e.g. /tmp vs ~/.mcpc)
   const tempFile = join(getMcpcHome(), `.sessions-${Date.now()}-${process.pid}.tmp`);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,7 +119,7 @@ export interface SessionData {
   name: string;
   server: ServerConfig; // Transport configuration (header values redacted to "<redacted>")
   profileName?: string; // Name of auth profile (for OAuth servers)
-  walletName?: string; // x402 wallet name for automatic payment signing
+  x402?: boolean; // x402 auto-payment enabled for this session
   pid?: number; // Bridge process PID
   protocolVersion?: string; // Negotiated MCP version
   mcpSessionId?: string; // Server-assigned MCP session ID for resumption (Streamable HTTP only)
@@ -198,10 +198,8 @@ export interface AuthCredentials {
 
 /**
  * x402 wallet credentials sent from CLI to bridge via IPC
- * Only the wallet name is sent; bridge loads the private key from wallets.json
  */
 export interface X402WalletCredentials {
-  walletName: string;
   address: string;
   privateKey: string; // Hex with 0x prefix
 }
@@ -277,9 +275,9 @@ export interface McpConfig {
 
 /**
  * x402 wallet data stored in ~/.mcpc/wallets.json
+ * Only a single wallet is supported (no names needed)
  */
 export interface WalletData {
-  name: string;
   address: string;
   privateKey: string; // Hex string starting with 0x
   createdAt: string; // ISO 8601
@@ -287,9 +285,11 @@ export interface WalletData {
 
 /**
  * Wallets storage structure (~/.mcpc/wallets.json)
+ * Versioned for future migration (e.g. multi-wallet support)
  */
 export interface WalletsStorage {
-  wallets: Record<string, WalletData>; // walletName -> WalletData
+  version: 1;
+  wallet?: WalletData;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,6 +119,7 @@ export interface SessionData {
   name: string;
   server: ServerConfig; // Transport configuration (header values redacted to "<redacted>")
   profileName?: string; // Name of auth profile (for OAuth servers)
+  walletName?: string; // x402 wallet name for automatic payment signing
   pid?: number; // Bridge process PID
   protocolVersion?: string; // Negotiated MCP version
   mcpSessionId?: string; // Server-assigned MCP session ID for resumption (Streamable HTTP only)
@@ -178,7 +179,8 @@ export type IpcMessageType =
   | 'response'
   | 'shutdown'
   | 'notification'
-  | 'set-auth-credentials';
+  | 'set-auth-credentials'
+  | 'set-x402-wallet';
 
 /**
  * Auth credentials sent from CLI to bridge via IPC
@@ -192,6 +194,16 @@ export interface AuthCredentials {
   refreshToken?: string;
   // HTTP headers (from --header flags, stored in keychain)
   headers?: Record<string, string>;
+}
+
+/**
+ * x402 wallet credentials sent from CLI to bridge via IPC
+ * Only the wallet name is sent; bridge loads the private key from wallets.json
+ */
+export interface X402WalletCredentials {
+  walletName: string;
+  address: string;
+  privateKey: string; // Hex with 0x prefix
 }
 
 /**
@@ -224,6 +236,7 @@ export interface IpcMessage {
   result?: unknown; // Response result
   notification?: NotificationData; // Notification data (for type='notification')
   authCredentials?: AuthCredentials; // Auth credentials (for type='set-auth-credentials')
+  x402Wallet?: X402WalletCredentials; // x402 wallet (for type='set-x402-wallet')
   error?: {
     code: number;
     message: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -263,6 +263,23 @@ export interface McpConfig {
 }
 
 /**
+ * x402 wallet data stored in ~/.mcpc/wallets.json
+ */
+export interface WalletData {
+  name: string;
+  address: string;
+  privateKey: string; // Hex string starting with 0x
+  createdAt: string; // ISO 8601
+}
+
+/**
+ * Wallets storage structure (~/.mcpc/wallets.json)
+ */
+export interface WalletsStorage {
+  wallets: Record<string, WalletData>; // walletName -> WalletData
+}
+
+/**
  * Combined server details returned by getServerDetails()
  * Structure matches MCP InitializeResult for consistency
  * Fetched once during initialization, cached locally

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,6 +93,13 @@ export function getAuthProfilesFilePath(): string {
 }
 
 /**
+ * Get the wallets file path (~/.mcpc/wallets.json)
+ */
+export function getWalletsFilePath(): string {
+  return join(getMcpcHome(), 'wallets.json');
+}
+
+/**
  * Ensure a directory exists, creating it if necessary
  */
 export async function ensureDir(dirPath: string): Promise<void> {

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -1,6 +1,6 @@
 /**
  * Wallet management for x402 payments
- * Stores wallet metadata and private keys in ~/.mcpc/wallets.json
+ * Stores a single wallet in ~/.mcpc/wallets.json
  */
 
 import { readFile, writeFile, rename, unlink } from 'fs/promises';
@@ -10,40 +10,32 @@ import { getWalletsFilePath, fileExists, ensureDir, getMcpcHome } from './utils.
 import { withFileLock } from './file-lock.js';
 import { ClientError } from './errors.js';
 
-const DEFAULT_WALLET_NAME = 'default';
-const WALLETS_DEFAULT_CONTENT = JSON.stringify({ wallets: {} }, null, 2);
-
-/**
- * Resolve wallet name, defaulting to "default"
- */
-export function resolveWalletName(name?: string): string {
-  return name || DEFAULT_WALLET_NAME;
-}
+const WALLETS_DEFAULT_CONTENT = JSON.stringify({ version: 1 }, null, 2);
 
 // ---------------------------------------------------------------------------
 // Internal read/write (called under file lock)
 // ---------------------------------------------------------------------------
 
-async function loadWalletsInternal(): Promise<WalletsStorage> {
+async function loadStorageInternal(): Promise<WalletsStorage> {
   const filePath = getWalletsFilePath();
 
   if (!(await fileExists(filePath))) {
-    return { wallets: {} };
+    return { version: 1 };
   }
 
   try {
     const content = await readFile(filePath, 'utf-8');
     const storage = JSON.parse(content) as WalletsStorage;
-    if (!storage.wallets || typeof storage.wallets !== 'object') {
-      return { wallets: {} };
+    if (!storage.version) {
+      return { version: 1 };
     }
     return storage;
   } catch {
-    return { wallets: {} };
+    return { version: 1 };
   }
 }
 
-async function saveWalletsInternal(storage: WalletsStorage): Promise<void> {
+async function saveStorageInternal(storage: WalletsStorage): Promise<void> {
   const filePath = getWalletsFilePath();
   await ensureDir(getMcpcHome());
 
@@ -57,7 +49,7 @@ async function saveWalletsInternal(storage: WalletsStorage): Promise<void> {
     } catch {
       /* ignore */
     }
-    throw new ClientError(`Failed to save wallets: ${(error as Error).message}`);
+    throw new ClientError(`Failed to save wallet: ${(error as Error).message}`);
   }
 }
 
@@ -65,13 +57,15 @@ async function saveWalletsInternal(storage: WalletsStorage): Promise<void> {
 // Public API (all operations hold file lock)
 // ---------------------------------------------------------------------------
 
-export async function loadWallets(): Promise<WalletsStorage> {
-  return withFileLock(getWalletsFilePath(), loadWalletsInternal, WALLETS_DEFAULT_CONTENT);
-}
-
-export async function getWallet(name: string): Promise<WalletData | undefined> {
-  const storage = await loadWallets();
-  return storage.wallets[name];
+export async function getWallet(): Promise<WalletData | undefined> {
+  return withFileLock(
+    getWalletsFilePath(),
+    async () => {
+      const storage = await loadStorageInternal();
+      return storage.wallet;
+    },
+    WALLETS_DEFAULT_CONTENT
+  );
 }
 
 export async function saveWallet(wallet: WalletData): Promise<void> {
@@ -79,23 +73,23 @@ export async function saveWallet(wallet: WalletData): Promise<void> {
   await withFileLock(
     filePath,
     async () => {
-      const storage = await loadWalletsInternal();
-      storage.wallets[wallet.name] = wallet;
-      await saveWalletsInternal(storage);
+      const storage = await loadStorageInternal();
+      storage.wallet = wallet;
+      await saveStorageInternal(storage);
     },
     WALLETS_DEFAULT_CONTENT
   );
 }
 
-export async function removeWallet(name: string): Promise<boolean> {
+export async function removeWallet(): Promise<boolean> {
   const filePath = getWalletsFilePath();
   return withFileLock(
     filePath,
     async () => {
-      const storage = await loadWalletsInternal();
-      if (!storage.wallets[name]) return false;
-      delete storage.wallets[name];
-      await saveWalletsInternal(storage);
+      const storage = await loadStorageInternal();
+      if (!storage.wallet) return false;
+      delete storage.wallet;
+      await saveStorageInternal(storage);
       return true;
     },
     WALLETS_DEFAULT_CONTENT

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -1,0 +1,103 @@
+/**
+ * Wallet management for x402 payments
+ * Stores wallet metadata and private keys in ~/.mcpc/wallets.json
+ */
+
+import { readFile, writeFile, rename, unlink } from 'fs/promises';
+import { join } from 'path';
+import type { WalletData, WalletsStorage } from './types.js';
+import { getWalletsFilePath, fileExists, ensureDir, getMcpcHome } from './utils.js';
+import { withFileLock } from './file-lock.js';
+import { ClientError } from './errors.js';
+
+const DEFAULT_WALLET_NAME = 'default';
+const WALLETS_DEFAULT_CONTENT = JSON.stringify({ wallets: {} }, null, 2);
+
+/**
+ * Resolve wallet name, defaulting to "default"
+ */
+export function resolveWalletName(name?: string): string {
+  return name || DEFAULT_WALLET_NAME;
+}
+
+// ---------------------------------------------------------------------------
+// Internal read/write (called under file lock)
+// ---------------------------------------------------------------------------
+
+async function loadWalletsInternal(): Promise<WalletsStorage> {
+  const filePath = getWalletsFilePath();
+
+  if (!(await fileExists(filePath))) {
+    return { wallets: {} };
+  }
+
+  try {
+    const content = await readFile(filePath, 'utf-8');
+    const storage = JSON.parse(content) as WalletsStorage;
+    if (!storage.wallets || typeof storage.wallets !== 'object') {
+      return { wallets: {} };
+    }
+    return storage;
+  } catch {
+    return { wallets: {} };
+  }
+}
+
+async function saveWalletsInternal(storage: WalletsStorage): Promise<void> {
+  const filePath = getWalletsFilePath();
+  await ensureDir(getMcpcHome());
+
+  const tempFile = join(getMcpcHome(), `.wallets-${Date.now()}-${process.pid}.tmp`);
+  try {
+    await writeFile(tempFile, JSON.stringify(storage, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    await rename(tempFile, filePath);
+  } catch (error) {
+    try {
+      await unlink(tempFile);
+    } catch {
+      /* ignore */
+    }
+    throw new ClientError(`Failed to save wallets: ${(error as Error).message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API (all operations hold file lock)
+// ---------------------------------------------------------------------------
+
+export async function loadWallets(): Promise<WalletsStorage> {
+  return withFileLock(getWalletsFilePath(), loadWalletsInternal, WALLETS_DEFAULT_CONTENT);
+}
+
+export async function getWallet(name: string): Promise<WalletData | undefined> {
+  const storage = await loadWallets();
+  return storage.wallets[name];
+}
+
+export async function saveWallet(wallet: WalletData): Promise<void> {
+  const filePath = getWalletsFilePath();
+  await withFileLock(
+    filePath,
+    async () => {
+      const storage = await loadWalletsInternal();
+      storage.wallets[wallet.name] = wallet;
+      await saveWalletsInternal(storage);
+    },
+    WALLETS_DEFAULT_CONTENT
+  );
+}
+
+export async function removeWallet(name: string): Promise<boolean> {
+  const filePath = getWalletsFilePath();
+  return withFileLock(
+    filePath,
+    async () => {
+      const storage = await loadWalletsInternal();
+      if (!storage.wallets[name]) return false;
+      delete storage.wallets[name];
+      await saveWalletsInternal(storage);
+      return true;
+    },
+    WALLETS_DEFAULT_CONTENT
+  );
+}

--- a/src/lib/x402/fetch-middleware.ts
+++ b/src/lib/x402/fetch-middleware.ts
@@ -1,0 +1,270 @@
+/**
+ * x402 fetch middleware for MCP transport
+ *
+ * Wraps the fetch function used by StreamableHTTPClientTransport to:
+ * 1. Proactively sign payments when tool metadata includes _meta.x402
+ * 2. Handle HTTP 402 responses by parsing PAYMENT-REQUIRED, signing, and retrying once
+ *
+ * This middleware is injected into the transport via the SDK's `fetch` option.
+ */
+
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import {
+  signPayment,
+  parsePaymentRequired,
+  type SignerWallet,
+  type PaymentRequiredAccept,
+  type PaymentRequiredHeader,
+} from './signer.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('x402-middleware');
+
+/** Payment information from tool's _meta.x402 */
+interface ToolPaymentMeta {
+  paymentRequired: boolean;
+  scheme?: string;
+  network?: string;
+  amount?: string;
+  asset?: string;
+  payTo?: string;
+  maxTimeoutSeconds?: number;
+  extra?: { name?: string; version?: string };
+}
+
+/** Parsed JSON-RPC request body (enough to identify tools/call) */
+interface JsonRpcRequest {
+  method?: string;
+  params?: {
+    name?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Options for creating the x402 fetch middleware
+ */
+export interface X402FetchMiddlewareOptions {
+  /** The wallet to sign payments with */
+  wallet: SignerWallet;
+
+  /**
+   * Callback to look up a tool by name to check _meta.x402.
+   * Returns the tool if found, undefined otherwise.
+   * This is called per tools/call request for proactive signing.
+   */
+  getToolByName?: (name: string) => Tool | undefined;
+}
+
+/**
+ * Create a fetch middleware that handles x402 payments.
+ *
+ * Returns a FetchLike function that wraps the original fetch:
+ * - For tools/call POST requests: proactively sign if tool has _meta.x402
+ * - For any request returning 402: parse, sign, retry once
+ * - All other requests: pass through unchanged
+ */
+export function createX402FetchMiddleware(
+  baseFetch: FetchLike,
+  options: X402FetchMiddlewareOptions
+): FetchLike {
+  const { wallet, getToolByName } = options;
+
+  return async (url: string | URL, init?: RequestInit): Promise<Response> => {
+    // Try proactive signing for tools/call requests
+    const proactiveHeader = await tryProactiveSigning(init, wallet, getToolByName);
+    if (proactiveHeader) {
+      logger.debug('Proactively signing x402 payment for tools/call');
+      const enhancedInit = injectPaymentHeader(init, proactiveHeader);
+      const response = await baseFetch(url, enhancedInit);
+
+      // If proactive signing succeeded (not 402), return immediately
+      if (response.status !== 402) {
+        return response;
+      }
+
+      // Proactive signing failed with 402 — fall through to 402 fallback
+      logger.debug('Proactive payment rejected (402), falling back to 402 handler');
+      return handle402Fallback(url, init, response, baseFetch, wallet);
+    }
+
+    // No proactive signing — make request normally
+    const response = await baseFetch(url, init);
+
+    // Check for 402 fallback
+    if (response.status === 402) {
+      return handle402Fallback(url, init, response, baseFetch, wallet);
+    }
+
+    return response;
+  };
+}
+
+/**
+ * Try to proactively sign a payment based on tool metadata.
+ * Returns the base64-encoded PAYMENT-SIGNATURE header, or undefined if not applicable.
+ */
+async function tryProactiveSigning(
+  init: RequestInit | undefined,
+  wallet: SignerWallet,
+  getToolByName?: (name: string) => Tool | undefined
+): Promise<string | undefined> {
+  if (!getToolByName || !init?.body) {
+    return undefined;
+  }
+
+  // Only handle POST requests (tools/call is always POST)
+  if (init.method && init.method.toUpperCase() !== 'POST') {
+    return undefined;
+  }
+
+  // Parse the request body to find tools/call requests
+  const toolName = extractToolCallName(init.body);
+  if (!toolName) {
+    return undefined;
+  }
+
+  // Look up tool metadata
+  const tool = getToolByName(toolName);
+  if (!tool) {
+    logger.debug(`Tool "${toolName}" not found in cache, skipping proactive signing`);
+    return undefined;
+  }
+
+  // Check _meta.x402
+  const meta = (tool as { _meta?: { x402?: ToolPaymentMeta } })._meta;
+  const x402 = meta?.x402;
+  if (!x402 || !x402.paymentRequired) {
+    return undefined;
+  }
+
+  // Check if we have enough info to sign proactively
+  if (!x402.scheme || !x402.network || !x402.amount || !x402.asset || !x402.payTo) {
+    logger.debug(
+      `Tool "${toolName}" has x402 metadata but missing fields, skipping proactive signing`
+    );
+    return undefined;
+  }
+
+  // Build accept from tool metadata
+  const accept: PaymentRequiredAccept = {
+    scheme: x402.scheme,
+    network: x402.network,
+    amount: x402.amount,
+    asset: x402.asset,
+    payTo: x402.payTo,
+    maxTimeoutSeconds: x402.maxTimeoutSeconds || 3600,
+    ...(x402.extra && { extra: x402.extra }),
+  };
+
+  try {
+    const result = await signPayment({ wallet, accept });
+    logger.debug(
+      `Proactive payment signed: $${result.amountUsd.toFixed(4)} to ${result.to} on ${result.networkLabel}`
+    );
+    return result.paymentSignatureBase64;
+  } catch (error) {
+    logger.warn(`Proactive signing failed for tool "${toolName}":`, error);
+    return undefined;
+  }
+}
+
+/**
+ * Handle a 402 response by parsing PAYMENT-REQUIRED, signing, and retrying once.
+ */
+async function handle402Fallback(
+  url: string | URL,
+  originalInit: RequestInit | undefined,
+  response402: Response,
+  baseFetch: FetchLike,
+  wallet: SignerWallet
+): Promise<Response> {
+  // Extract PAYMENT-REQUIRED header (case-insensitive)
+  const paymentRequiredBase64 =
+    response402.headers.get('PAYMENT-REQUIRED') || response402.headers.get('payment-required');
+
+  if (!paymentRequiredBase64) {
+    logger.debug('402 response has no PAYMENT-REQUIRED header, passing through');
+    return response402;
+  }
+
+  logger.debug('Received 402 with PAYMENT-REQUIRED header, signing payment...');
+
+  let header: PaymentRequiredHeader;
+  let accept: PaymentRequiredAccept;
+  try {
+    ({ header, accept } = parsePaymentRequired(paymentRequiredBase64));
+  } catch (error) {
+    logger.warn('Failed to parse PAYMENT-REQUIRED header:', error);
+    return response402;
+  }
+
+  // Sign the payment
+  try {
+    const result = await signPayment({
+      wallet,
+      accept,
+      resource: header.resource,
+    });
+
+    logger.debug(
+      `402 fallback payment signed: $${result.amountUsd.toFixed(4)} to ${result.to} on ${result.networkLabel}`
+    );
+
+    // Retry with payment signature (once only)
+    const retryInit = injectPaymentHeader(originalInit, result.paymentSignatureBase64);
+    return await baseFetch(url, retryInit);
+  } catch (error) {
+    logger.warn('402 fallback signing failed:', error);
+    return response402;
+  }
+}
+
+/**
+ * Extract the tool name from a JSON-RPC tools/call request body.
+ * Returns undefined if the body isn't a tools/call request.
+ */
+function extractToolCallName(body: RequestInit['body'] | undefined): string | undefined {
+  if (!body || typeof body !== 'string') {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(body);
+
+    // Handle single request
+    if (!Array.isArray(parsed)) {
+      const req = parsed as JsonRpcRequest;
+      if (req.method === 'tools/call' && req.params?.name) {
+        return req.params.name;
+      }
+      return undefined;
+    }
+
+    // Handle batch — find first tools/call
+    for (const item of parsed) {
+      const req = item as JsonRpcRequest;
+      if (req.method === 'tools/call' && req.params?.name) {
+        return req.params.name;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Clone a RequestInit and add/overwrite the PAYMENT-SIGNATURE header.
+ */
+function injectPaymentHeader(init: RequestInit | undefined, paymentSignature: string): RequestInit {
+  const headers = new Headers(init?.headers);
+  headers.set('PAYMENT-SIGNATURE', paymentSignature);
+
+  return {
+    ...init,
+    headers,
+  };
+}

--- a/src/lib/x402/signer.ts
+++ b/src/lib/x402/signer.ts
@@ -1,0 +1,265 @@
+/**
+ * x402 payment signing logic
+ * Reusable module for signing EIP-3009 TransferWithAuthorization payments.
+ * Used by both the CLI `x402 sign` command and the fetch middleware.
+ */
+
+import { privateKeyToAccount } from 'viem/accounts';
+import { createWalletClient, http, type Hex } from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+import { ClientError } from '../errors.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const X402_VERSION = 2;
+const USDC_DECIMALS = 6;
+
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+} as const;
+
+// ---------------------------------------------------------------------------
+// Network configs
+// ---------------------------------------------------------------------------
+
+interface NetworkConfig {
+  chain: typeof base | typeof baseSepolia;
+  networkId: string;
+  rpcUrl: string;
+  label: string;
+}
+
+const NETWORKS: Record<string, NetworkConfig> = {
+  [`eip155:${base.id}`]: {
+    chain: base,
+    networkId: `eip155:${base.id}`,
+    rpcUrl: 'https://mainnet.base.org',
+    label: 'Base Mainnet',
+  },
+  [`eip155:${baseSepolia.id}`]: {
+    chain: baseSepolia,
+    networkId: `eip155:${baseSepolia.id}`,
+    rpcUrl: 'https://sepolia.base.org',
+    label: 'Base Sepolia (testnet)',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PaymentRequiredAccept {
+  scheme: string;
+  network: string;
+  amount: string;
+  asset: string;
+  payTo: string;
+  maxTimeoutSeconds: number;
+  extra?: { name?: string; version?: string };
+}
+
+export interface PaymentRequiredHeader {
+  x402Version: number;
+  resource?: { url?: string; description?: string; mimeType?: string };
+  accepts: PaymentRequiredAccept[];
+}
+
+/** Minimal wallet info needed for signing */
+export interface SignerWallet {
+  privateKey: string; // Hex with 0x prefix
+  address: string;
+}
+
+export interface SignPaymentInput {
+  wallet: SignerWallet;
+  accept: PaymentRequiredAccept;
+  resource?: PaymentRequiredHeader['resource'];
+  /** Override amount in atomic units (default: from accept.amount) */
+  amountOverride?: bigint;
+  /** Override expiry in seconds (default: from accept.maxTimeoutSeconds or 3600) */
+  expiryOverride?: number;
+}
+
+export interface SignPaymentResult {
+  /** Base64-encoded payment signature header value */
+  paymentSignatureBase64: string;
+  /** Signer address */
+  from: string;
+  /** Recipient address */
+  to: string;
+  /** Amount in USD */
+  amountUsd: number;
+  /** Amount in atomic units */
+  amountAtomicUnits: bigint;
+  /** Network label */
+  networkLabel: string;
+  /** Expiry timestamp */
+  expiresAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
+
+function randomBytes32(): Hex {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return ('0x' + [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')) as Hex;
+}
+
+// ---------------------------------------------------------------------------
+// PAYMENT-REQUIRED header parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a base64-encoded PAYMENT-REQUIRED header value
+ * Returns the parsed header and the first "exact" scheme accept entry
+ */
+export function parsePaymentRequired(base64Value: string): {
+  header: PaymentRequiredHeader;
+  accept: PaymentRequiredAccept;
+} {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(base64Value, 'base64').toString('utf-8');
+  } catch {
+    throw new ClientError('Failed to base64-decode the PAYMENT-REQUIRED value.');
+  }
+
+  let header: PaymentRequiredHeader;
+  try {
+    header = JSON.parse(decoded) as PaymentRequiredHeader;
+  } catch {
+    throw new ClientError('PAYMENT-REQUIRED header is not valid JSON after base64 decoding.');
+  }
+
+  if (!header.accepts || !Array.isArray(header.accepts) || header.accepts.length === 0) {
+    throw new ClientError('PAYMENT-REQUIRED header has no "accepts" entries.');
+  }
+
+  const accept = header.accepts.find((a) => a.scheme === 'exact');
+  if (!accept) {
+    throw new ClientError(
+      `No "exact" scheme found in PAYMENT-REQUIRED accepts. Available: ${header.accepts.map((a) => a.scheme).join(', ')}`
+    );
+  }
+
+  if (!accept.payTo || !accept.amount || !accept.network || !accept.asset) {
+    throw new ClientError(
+      'PAYMENT-REQUIRED accept entry is missing required fields (payTo, amount, network, asset).'
+    );
+  }
+
+  return { header, accept };
+}
+
+// ---------------------------------------------------------------------------
+// Signing
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign an x402 payment and return a base64-encoded PAYMENT-SIGNATURE header value
+ */
+export async function signPayment(input: SignPaymentInput): Promise<SignPaymentResult> {
+  const { wallet, accept, resource } = input;
+
+  // Resolve network
+  const networkConfig = NETWORKS[accept.network];
+  if (!networkConfig) {
+    throw new ClientError(
+      `Unknown network "${accept.network}" in payment requirements. Supported: ${Object.keys(NETWORKS).join(', ')}`
+    );
+  }
+
+  // Resolve amount
+  const amountAtomicUnits = input.amountOverride ?? BigInt(accept.amount);
+  const amountUsd = Number(amountAtomicUnits) / 10 ** USDC_DECIMALS;
+
+  // Resolve expiry
+  const expirySeconds = (input.expiryOverride ?? accept.maxTimeoutSeconds) || 3600;
+
+  // EIP-3009 domain
+  const eip3009Name = accept.extra?.name ?? 'USDC';
+  const eip3009Version = accept.extra?.version ?? '2';
+
+  // Sign
+  const account = privateKeyToAccount(wallet.privateKey as Hex);
+  const walletClient = createWalletClient({
+    account,
+    chain: networkConfig.chain,
+    transport: http(networkConfig.rpcUrl),
+  });
+
+  const nonce = randomBytes32();
+  const validBefore = BigInt(Math.floor(Date.now() / 1000) + expirySeconds);
+
+  const signature = await walletClient.signTypedData({
+    domain: {
+      name: eip3009Name,
+      version: eip3009Version,
+      chainId: networkConfig.chain.id,
+      verifyingContract: accept.asset as Hex,
+    },
+    types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+    primaryType: 'TransferWithAuthorization',
+    message: {
+      from: account.address,
+      to: accept.payTo as Hex,
+      value: amountAtomicUnits,
+      validAfter: 0n,
+      validBefore,
+      nonce,
+    },
+  });
+
+  // Build x402 payload
+  const paymentPayload = {
+    x402Version: X402_VERSION,
+    resource: resource ?? {
+      url: 'https://mcp.apify.com/mcp',
+      description: 'MCP Server',
+      mimeType: 'application/json',
+    },
+    payload: {
+      signature,
+      authorization: {
+        from: account.address,
+        to: accept.payTo,
+        value: amountAtomicUnits.toString(),
+        validAfter: '0',
+        validBefore: validBefore.toString(),
+        nonce,
+      },
+    },
+    accepted: {
+      scheme: 'exact',
+      network: networkConfig.networkId,
+      asset: accept.asset,
+      amount: amountAtomicUnits.toString(),
+      payTo: accept.payTo,
+      maxTimeoutSeconds: expirySeconds,
+      extra: { name: eip3009Name, version: eip3009Version },
+    },
+  };
+
+  const paymentSignatureBase64 = Buffer.from(JSON.stringify(paymentPayload)).toString('base64');
+
+  return {
+    paymentSignatureBase64,
+    from: account.address,
+    to: accept.payTo,
+    amountUsd,
+    amountAtomicUnits,
+    networkLabel: networkConfig.label,
+    expiresAt: new Date(Number(validBefore) * 1000),
+  };
+}


### PR DESCRIPTION
## Summary

Add x402 payment protocol support — automatic USDC payments for paid MCP tools on Base/Base Sepolia.

- `mcpc x402 init|import|info|remove|sign` for wallet management
- `--x402` flag enables auto-payment on both direct and session connections
- Two signing paths: proactive (bridge reads `_meta.x402` from tools list) and 402 fallback (retry on HTTP 402)
- Single wallet in `~/.mcpc/wallets.json` (versioned format, `0600` perms)
- `viem` for EIP-3009 signing, custom `fetch` wrapper via SDK transport
- Bridge receives wallet via IPC, never as CLI args

Tested e2e against local x402 demo server (direct + bridge, paid + free tools). All existing tests pass except pre-existing flaky `bridge-resilience` (parallel test pollution causes INVARIANT VIOLATION — unrelated to x402).