### PR TITLE
fix: flush stdout before process.exit() to prevent pipe truncation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -227,6 +227,18 @@ async function main(): Promise<void> {
     await closeFileLogger();
   }
 
+  // Flush stdout before exiting. When stdout is a pipe, Node.js uses async I/O
+  // and process.exit() would discard any data still in the stream buffer.
+  // This caused silent truncation at 64KB (the kernel pipe buffer size).
+  await new Promise<void>((resolve) => {
+    if (process.stdout.writableFinished) {
+      resolve();
+    } else {
+      process.stdout.once('finish', resolve);
+      process.stdout.end();
+    }
+  });
+
   // Explicit exit to avoid waiting for stdio child processes to close
   // (the MCP SDK's StdioClientTransport keeps handles in the event loop)
   process.exit(0);


### PR DESCRIPTION
## Summary

When mcpc JSON output exceeds 64KB and stdout is piped (e.g. `mcpc ... --json | jq`), the output is **silently truncated** at exactly 65,536 bytes, producing broken JSON that downstream parsers can't read.

## Root cause

`src/cli/index.ts` line 232 calls `process.exit(0)` after command execution. When stdout is a pipe, Node.js uses async I/O — `console.log()` buffers data internally and flushes it asynchronously. `process.exit()` terminates the process before the buffer is fully written to the pipe, discarding any data beyond the 64KB kernel pipe buffer.

When stdout is a file or TTY, Node.js uses synchronous `writeSync()`, so all data is written before `process.exit()` runs — which is why `mcpc ... --json > file.json` always works.

## Reproduction

```bash
# Pipe: truncated at exactly 64KB
mcpc @apify tools-call get-actor-output datasetId:="<large>" limit:=25 --json 2>/dev/null | wc -c
# → 65536

# File redirect: complete output
mcpc @apify tools-call get-actor-output datasetId:="<large>" limit:=25 --json > /tmp/out.json 2>/dev/null && wc -c /tmp/out.json
# → 118166

# jq fails with broken JSON
mcpc ... --json | jq '.structuredContent.items'
# → jq: parse error: Unfinished string at EOF at line 194, column 22
```

## Fix

Wait for stdout to fully drain before calling `process.exit(0)`. The exit itself is still needed (MCP SDK's StdioClientTransport keeps the event loop alive), but now it only fires after all buffered data has been flushed.

## Verified

```bash
# After fix — pipe returns complete output
mcpc ... --json 2>/dev/null | wc -c
# → 118166 ✓

# jq parses correctly
mcpc ... --json | jq '.structuredContent | {totalItemCount, count: (.items | length)}'
# → {"totalItemCount": 25, "count": 25} ✓

# File redirect still works, process exits cleanly (no hang)
```

## Test plan

- [ ] Pipe output >64KB through jq — should parse without errors
- [ ] File redirect — should produce identical byte count as pipe
- [ ] Process should exit cleanly (no hanging from MCP SDK handles)
- [ ] Small outputs (<64KB) should still work correctly through pipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)