### PR TITLE
Add architecture diagrams to README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,25 @@ and enables long-term stateful sessions.
 The sessions are given names prefixed with `@` (e.g. `@apify`),
 which then serve as unique reference in commands.
 
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                          Session architecture                               │
+│                                                                             │
+│  Terminal / Script                  Bridge process             MCP server   │
+│  ┌─────────────┐               ┌──────────────────┐       ┌─────────────┐  │
+│  │ mcpc @apify │──Unix socket──│  mcpc-bridge      │──HTTP─│ mcp.apify.  │  │
+│  │ tools-list  │   ~/.mcpc/    │  (persistent)     │  or   │ com         │  │
+│  └─────────────┘  bridges/     │  - MCP session    │ stdio └─────────────┘  │
+│                   apify.sock   │  - Auth tokens    │                        │
+│  ┌─────────────┐               │  - Notifications  │       ┌─────────────┐  │
+│  │ mcpc @apify │──Unix socket──│  - Caching        │──HTTP─│ another     │  │
+│  │ tools-call  │               └──────────────────┘│  or   │ server      │  │
+│  └─────────────┘                                   │ stdio └─────────────┘  │
+│                                                                             │
+│  Multiple CLI calls share the same bridge process and MCP session.          │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
 ```bash
 # Create a persistent session
 mcpc connect mcp.apify.com @apify
@@ -310,6 +329,25 @@ The sessions are persistent: metadata is saved in `~/.mcpc/sessions.json` file,
 [authentication tokens](#authentication) in OS keychain.
 The `mcpc` bridge process keeps the session alive by sending periodic [ping messages](#ping) to the MCP server.
 Still, sessions can fail due to network disconnects, bridge process crash, or server dropping it.
+
+```
+  mcpc connect             mcpc @apify             mcpc @apify close
+  mcp.apify.com @apify     tools-list              (or: mcpc close @apify)
+        │                      │                          │
+        ▼                      ▼                          ▼
+  ┌───────────┐          ┌───────────┐              ┌───────────┐
+  │  Spawn    │          │  Connect  │              │  Kill     │
+  │  bridge   │─────────▶│  to sock  │              │  bridge   │
+  │  process  │          │  Send req │              │  Remove   │
+  └───────────┘          └───────────┘              │  session  │
+        │                      │                    └───────────┘
+        ▼                      ▼
+  Bridge creates         Bridge forwards
+  Unix socket &          request to MCP
+  MCP session            server, returns
+  (initialize →          response via
+   initialized)          socket
+```
 
 **Session states:**
 
@@ -387,6 +425,53 @@ dynamic client registration, and automatic token refresh.
 
 The OAuth authentication **always** needs to be initiated by the user calling the `login` command,
 which opens a web browser with login screen. `mcpc` never opens the web browser on its own.
+
+```
+                        OAuth 2.1 login flow
+                        ────────────────────
+
+  mcpc login                                       Auth server
+  mcp.apify.com          Browser                  (e.g. auth.apify.com)
+       │                    │                            │
+       │  1. Discover OAuth metadata (WWW-Authenticate)  │
+       │────────────────────────────────────────────────▶│
+       │◀────────────────────────────────────────────────│
+       │                    │                            │
+       │  2. Open login URL │                            │
+       │───────────────────▶│  3. User logs in           │
+       │                    │───────────────────────────▶│
+       │                    │◀───────────────────────────│
+       │                    │  4. Redirect to localhost   │
+       │◀───────────────────│     with auth code         │
+       │                    │                            │
+       │  5. Exchange code for tokens (PKCE)             │
+       │────────────────────────────────────────────────▶│
+       │◀────────────────────────────────────────────────│
+       │                                                 │
+       ▼
+  Save to OS keychain
+  + profiles.json
+```
+
+```
+               Profiles and sessions relationship
+               ───────────────────────────────────
+
+  ┌──────────────────┐     ┌──────────────────────────────────────┐
+  │ profiles.json    │     │ sessions.json                        │
+  │                  │     │                                      │
+  │  mcp.apify.com:  │◀────│  @apify-personal  (profile: default) │
+  │    default: {...}│     │  @apify-work      (profile: work)    │
+  │    work:    {...}│◀────│                                      │
+  └──────────────────┘     └──────────────────────────────────────┘
+           │
+           ▼
+  ┌──────────────────┐
+  │   OS keychain    │
+  │  (OAuth tokens,  │
+  │   refresh tokens)│
+  └──────────────────┘
+```
 
 The OAuth credentials to specific servers are securely stored as **authentication profiles** - reusable
 credentials that allow you to:
@@ -483,6 +568,24 @@ The proxy forwards all MCP requests to the upstream server but **never exposes t
 This is useful when you want to give someone or something MCP access without revealing your credentials.
 See also [AI sandboxes](#ai-sandboxes).
 
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │                        MCP proxy setup                              │
+  │                                                                     │
+  │  Human sets up:                                                     │
+  │    mcpc login mcp.apify.com                                         │
+  │    mcpc connect mcp.apify.com @relay --proxy 8080                   │
+  │                                                                     │
+  │                   ┌────────────────┐                                 │
+  │  AI sandbox ──────│ Proxy server   │──── mcp.apify.com              │
+  │  (localhost:8080) │ (bridge)       │     (with OAuth tokens)        │
+  │                   └────────────────┘                                 │
+  │                                                                     │
+  │  The AI only sees localhost:8080.                                    │
+  │  Original OAuth tokens and HTTP headers are never exposed.          │
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
 ```bash
 # Human authenticates to a remote server
 mcpc login mcp.apify.com
@@ -544,6 +647,29 @@ interactive **tool calling** and **[code mode](https://www.anthropic.com/enginee
 **Tool calling mode** - Agents call `mcpc` commands to dynamically explore and interact with MCP servers,
 using the default text output. This is similar to how MCP connectors in ChatGPT or Claude work,
 but CLI gives you more flexibility and longer operation timeouts.
+
+```
+           AI agent tool calling flow
+           ──────────────────────────
+
+  AI Agent                  mcpc CLI                 MCP Server
+     │                         │                         │
+     │  1. tools-list          │                         │
+     │────────────────────────▶│  tools/list              │
+     │  (discover tools)       │────────────────────────▶│
+     │◀────────────────────────│◀────────────────────────│
+     │                         │                         │
+     │  2. tools-get search    │                         │
+     │────────────────────────▶│  tools/list (cached)     │
+     │  (read schema)          │────────────────────────▶│
+     │◀────────────────────────│◀────────────────────────│
+     │                         │                         │
+     │  3. tools-call search   │  tools/call              │
+     │     query:="hello"      │                         │
+     │────────────────────────▶│────────────────────────▶│
+     │◀────────────────────────│◀────────────────────────│
+     │  (result)               │                         │
+```
 
 ```bash
 # Discover available tools
@@ -651,6 +777,23 @@ on the [Base](https://base.org/) blockchain and retries the request — no human
 This is entirely **opt-in**: existing functionality is unaffected unless you explicitly pass the `--x402` flag.
 
 ### How it works
+
+```
+  mcpc                            MCP Server               Blockchain
+    │  1. tools/call                   │                       │
+    │─────────────────────────────────▶│                       │
+    │  HTTP 402 + PAYMENT-REQUIRED     │                       │
+    │◀─────────────────────────────────│                       │
+    │                                  │                       │
+    │  2. Sign USDC payment locally    │                       │
+    │  (EIP-3009 TransferWithAuth)     │                       │
+    │                                  │                       │
+    │  3. Retry + PAYMENT-SIGNATURE    │                       │
+    │─────────────────────────────────▶│  4. Verify & settle   │
+    │                                  │──────────────────────▶│
+    │  5. Tool result                  │◀──────────────────────│
+    │◀─────────────────────────────────│                       │
+```
 
 1. **Server returns HTTP 402** with a `PAYMENT-REQUIRED` header describing the price and payment details.
 2. `mcpc` parses the header, signs an [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) `TransferWithAuthorization` using your local wallet.


### PR DESCRIPTION
## Summary
This PR adds comprehensive ASCII diagrams to the README to visually explain key architectural concepts and workflows in the mcpc tool. These diagrams improve documentation clarity by providing visual representations of complex processes.

## Key Changes
- **Session architecture diagram**: Illustrates how terminal/script commands communicate with the bridge process and MCP servers via Unix sockets
- **Session lifecycle diagram**: Shows the flow of session creation, connection, and termination
- **OAuth 2.1 login flow diagram**: Details the authentication process from discovery through token exchange and storage
- **Profiles and sessions relationship diagram**: Visualizes how profiles.json, sessions.json, and OS keychain interact
- **MCP proxy setup diagram**: Explains how the proxy forwards requests while protecting credentials
- **AI agent tool calling flow diagram**: Shows the sequence of tools-list, tools-get, and tools-call operations
- **Payment flow diagram**: Illustrates the HTTP 402 payment-required flow with blockchain settlement

## Implementation Details
All diagrams are added as code blocks in the README.md file at relevant sections, providing visual context immediately before or after the related text explanations. The diagrams use ASCII art with box-drawing characters for clarity and are formatted consistently throughout the document.

https://claude.ai/code/session_01CLP1rPkK7YsRZTCi8gTzwp