### PR TITLE
Cap IPC buffer size at 10 MB to prevent unbounded memory growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - E2E tests now run under the Bun runtime (in addition to Node.js); use `./test/e2e/run.sh --runtime bun` or `npm run test:e2e:bun`
 
 ### Fixed
+- IPC buffer between CLI and bridge process is now capped at 10 MB; sockets are destroyed if the limit is exceeded, preventing unbounded memory growth
 - `validateOptions()` no longer includes subcommand-specific options (`--full`, `--x402`, `--proxy`, etc.) in global known-options list; misplaced flags now produce clear "Unknown option" errors instead of confusing Commander rejections
 - Sessions requiring authentication now correctly show as `expired` instead of `live` when the server rejects unauthenticated connections
 - Auth errors wrapped in `NetworkError` by bridge IPC are now detected on first health check, avoiding unnecessary bridge restart

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -45,6 +45,9 @@ setGlobalDispatcher(new EnvHttpProxyAgent());
 // Keepalive ping interval in milliseconds (30 seconds)
 const KEEPALIVE_INTERVAL_MS = 30_000;
 
+// Maximum IPC buffer size (10 MB) — destroy socket if exceeded
+const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
 const logger = createLogger('bridge');
 
 interface BridgeOptions {
@@ -788,6 +791,13 @@ class BridgeProcess {
 
     socket.on('data', (data) => {
       buffer += data.toString();
+
+      if (buffer.length > MAX_BUFFER_SIZE) {
+        logger.error(`IPC buffer exceeded ${MAX_BUFFER_SIZE} bytes, destroying socket`);
+        socket.destroy();
+        this.connections.delete(socket);
+        return;
+      }
 
       // Process complete JSON messages (newline-delimited)
       let newlineIndex: number;

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -28,6 +28,9 @@ const REQUEST_TIMEOUT = 3 * 60 * 1000;
 // Timeout for initial socket connection (5 seconds)
 const CONNECT_TIMEOUT = 5 * 1000;
 
+// Maximum IPC buffer size (10 MB) — destroy socket if exceeded
+const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
 export class BridgeClient extends EventEmitter {
   private socket: Socket | null = null;
   private socketPath: string;
@@ -107,6 +110,13 @@ export class BridgeClient extends EventEmitter {
 
     this.socket.on('data', (data) => {
       this.buffer += data.toString();
+
+      if (this.buffer.length > MAX_BUFFER_SIZE) {
+        logger.error(`IPC buffer exceeded ${MAX_BUFFER_SIZE} bytes, destroying socket`);
+        this.socket?.destroy();
+        this.cleanup();
+        return;
+      }
 
       // Process complete JSON messages (newline-delimited)
       let newlineIndex: number;


### PR DESCRIPTION
## Summary
This PR adds a buffer size limit to the IPC communication between the CLI and bridge process to prevent unbounded memory growth from malformed or excessively large messages.

## Changes
- Added `MAX_BUFFER_SIZE` constant (10 MB) to both `BridgeProcess` and `BridgeClient`
- Implemented buffer overflow detection in the `data` event handlers of both IPC endpoints
- When the buffer exceeds the limit, the socket is destroyed and cleaned up to prevent memory exhaustion
- Updated CHANGELOG to document the fix

## Implementation Details
- The check is performed after each data chunk is appended to the buffer
- If the limit is exceeded, an error is logged and the socket is immediately destroyed
- In `BridgeProcess`, the socket is removed from the connections map
- In `BridgeClient`, the cleanup method is called to properly release resources
- Both implementations follow the same pattern for consistency across the IPC layer

https://claude.ai/code/session_016foZUbDw68HevDoSakfUHF