### PR TITLE
Move --header option from global to connect-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - E2E tests now run under the Bun runtime (in addition to Node.js); use `./test/e2e/run.sh --runtime bun` or `npm run test:e2e:bun`
 
 ### Fixed
+- `--header` / `-H` option is now specific to the `connect` command instead of being shown as a global option in `mcpc --help`
 - IPC buffer between CLI and bridge process is now capped at 10 MB; sockets are destroyed if the limit is exceeded, preventing unbounded memory growth
 - `validateOptions()` no longer includes subcommand-specific options (`--full`, `--x402`, `--proxy`, etc.) in global known-options list; misplaced flags now produce clear "Unknown option" errors instead of confusing Commander rejections
 - Sessions requiring authentication now correctly show as `expired` instead of `live` when the server rejects unauthenticated connections

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -81,11 +81,6 @@ function getOptionsFromCommand(command: Command): HandlerOptions {
   };
 
   // Only include optional properties if they're present
-  if (opts.header) {
-    // Commander stores repeated options as arrays, but single values as strings
-    // Always convert to array for consistent handling
-    options.headers = Array.isArray(opts.header) ? opts.header : [opts.header];
-  }
   if (opts.timeout) {
     const timeout = parseInt(opts.timeout as string, 10);
     if (isNaN(timeout) || timeout <= 0) {
@@ -311,7 +306,6 @@ function createTopLevelProgram(): Command {
     )
     .usage('[options] [<@session>] [<command>]')
     .option('-j, --json', 'Output in JSON format for scripting')
-    .option('-H, --header <header>', 'HTTP header (can be repeated)')
     .option('--verbose', 'Enable debug logging')
     .option('--profile <name>', 'OAuth profile for the server ("default" if not provided)')
     .option('--schema <file>', 'Validate tool/prompt schema against expected schema')
@@ -348,6 +342,7 @@ Full docs: ${docsUrl}`
     .command('connect [server] [@session]')
     .usage('<server> <@session>')
     .description('Connect to an MCP server and start a new named @session')
+    .option('-H, --header <header>', 'HTTP header (can be repeated)')
     .option('--profile <name>', 'OAuth profile to use ("default" if skipped)')
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
@@ -374,6 +369,13 @@ Server formats:
       const globalOpts = getOptionsFromCommand(command);
       const parsed = parseServerArg(server);
 
+      // Extract --header from connect-specific opts
+      const headers: string[] | undefined = opts.header
+        ? Array.isArray(opts.header)
+          ? (opts.header as string[])
+          : [opts.header as string]
+        : undefined;
+
       if (!parsed) {
         throw new ClientError(
           `Invalid server: "${server}"\n\n` +
@@ -385,6 +387,7 @@ Server formats:
         // Config file entry: pass entry name as target with config file path
         await sessions.connectSession(parsed.entry, sessionName, {
           ...globalOpts,
+          ...(headers && { headers }),
           config: parsed.file,
           proxy: opts.proxy,
           proxyBearerToken: opts.proxyBearerToken,
@@ -393,6 +396,7 @@ Server formats:
       } else {
         await sessions.connectSession(server, sessionName, {
           ...globalOpts,
+          ...(headers && { headers }),
           proxy: opts.proxy,
           proxyBearerToken: opts.proxyBearerToken,
           x402: opts.x402,
@@ -773,7 +777,6 @@ function createSessionProgram(): Command {
     .name('mcpc <@session>')
     .helpOption('-h, --help', 'Display help')
     .option('-j, --json', 'Output in JSON format for scripting and code mode')
-    .option('-H, --header <header>', 'Custom HTTP header (can be repeated)')
     .option('--verbose', 'Enable debug logging')
     .option('--profile <name>', 'OAuth profile override')
     .option('--schema <file>', 'Validate tool/prompt schema against expected schema')

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -30,20 +30,15 @@ export function getJsonFromEnv(): boolean {
 }
 
 // Global options that take a value (not boolean flags)
-const GLOBAL_OPTIONS_WITH_VALUES = [
-  '-H',
-  '--header',
-  '--timeout',
-  '--profile',
-  '--schema',
-  '--schema-mode',
-];
+const GLOBAL_OPTIONS_WITH_VALUES = ['--timeout', '--profile', '--schema', '--schema-mode'];
 
 // All options that take a value — used by optionTakesValue() to correctly skip
 // the next arg when scanning for command tokens. Includes subcommand-specific
 // options so misplaced flags still get their values skipped during scanning.
 const OPTIONS_WITH_VALUES = [
   ...GLOBAL_OPTIONS_WITH_VALUES,
+  '-H',
+  '--header',
   '--proxy',
   '--proxy-bearer-token',
   '--scope',
@@ -237,7 +232,6 @@ export function validateArgValues(args: string[]): void {
  * Environment variables MCPC_VERBOSE and MCPC_JSON are used as defaults
  */
 export function extractOptions(args: string[]): {
-  headers?: string[];
   timeout?: number;
   profile?: string;
   x402?: boolean;
@@ -248,16 +242,6 @@ export function extractOptions(args: string[]): {
     verbose: args.includes('--verbose') || getVerboseFromEnv(),
     json: args.includes('--json') || args.includes('-j') || getJsonFromEnv(),
   };
-
-  // Extract --header (can be repeated)
-  const headers: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    const nextArg = args[i + 1];
-    if ((arg === '--header' || arg === '-H') && nextArg) {
-      headers.push(nextArg);
-    }
-  }
 
   // Extract --timeout
   const timeoutIndex = args.findIndex((arg) => arg === '--timeout');
@@ -275,7 +259,6 @@ export function extractOptions(args: string[]): {
 
   return {
     ...options,
-    ...(headers.length > 0 && { headers }),
     ...(timeout !== undefined && { timeout }),
     ...(profile && { profile }),
     ...(x402 && { x402 }),

--- a/test/unit/cli/index.test.ts
+++ b/test/unit/cli/index.test.ts
@@ -170,21 +170,19 @@ describe('extractOptions', () => {
     expect(result).toEqual({ json: true, verbose: false });
   });
 
-  it('should extract multiple --header options', () => {
+  it('should not extract --header (connect-specific option)', () => {
     const result = extractOptions(['--header', 'Auth: Bearer token', '--header', 'X-Key: value']);
     expect(result).toEqual({
       json: false,
       verbose: false,
-      headers: ['Auth: Bearer token', 'X-Key: value'],
     });
   });
 
-  it('should extract --header short form (-H)', () => {
+  it('should not extract -H short form (connect-specific option)', () => {
     const result = extractOptions(['-H', 'Auth: token', '-H', 'X-Key: value']);
     expect(result).toEqual({
       json: false,
       verbose: false,
-      headers: ['Auth: token', 'X-Key: value'],
     });
   });
 
@@ -193,19 +191,11 @@ describe('extractOptions', () => {
     expect(result).toEqual({ json: false, verbose: false, timeout: 120 });
   });
 
-  it('should extract all options together', () => {
-    const result = extractOptions([
-      '--json',
-      '--verbose',
-      '--header',
-      'Auth: token',
-      '--timeout',
-      '60',
-    ]);
+  it('should extract all global options together', () => {
+    const result = extractOptions(['--json', '--verbose', '--timeout', '60']);
     expect(result).toEqual({
       json: true,
       verbose: true,
-      headers: ['Auth: token'],
       timeout: 60,
     });
   });

--- a/test/unit/cli/parser.test.ts
+++ b/test/unit/cli/parser.test.ts
@@ -411,7 +411,6 @@ describe('validateOptions', () => {
   });
 
   it('should not throw for known value options with separate values', () => {
-    expect(() => validateOptions(['--header', 'Authorization: Bearer token'])).not.toThrow();
     expect(() => validateOptions(['--timeout', '30'])).not.toThrow();
     expect(() => validateOptions(['--profile', 'personal'])).not.toThrow();
   });
@@ -459,6 +458,9 @@ describe('validateOptions', () => {
     expect(() => validateOptions(['--output', 'out.txt'])).toThrow(ClientError);
     expect(() => validateOptions(['--client-id', 'abc'])).toThrow(ClientError);
     expect(() => validateOptions(['--payment-required', 'data'])).toThrow(ClientError);
+    // --header is connect-specific, not global
+    expect(() => validateOptions(['--header', 'Authorization: Bearer token'])).toThrow(ClientError);
+    expect(() => validateOptions(['-H', 'Authorization: Bearer token'])).toThrow(ClientError);
   });
 
   it('should accept subcommand-specific options after a command token', () => {
@@ -471,6 +473,13 @@ describe('validateOptions', () => {
     expect(() =>
       validateOptions(['login', 'srv', '--client-id', 'abc', '--client-secret', 'xyz'])
     ).not.toThrow();
+    // --header is accepted after connect command token
+    expect(() =>
+      validateOptions(['connect', 'srv', '@s', '--header', 'Authorization: Bearer token'])
+    ).not.toThrow();
+    expect(() =>
+      validateOptions(['connect', 'srv', '@s', '-H', 'Authorization: Bearer token'])
+    ).not.toThrow();
   });
 
   it('should accept empty args array', () => {
@@ -478,12 +487,10 @@ describe('validateOptions', () => {
   });
 
   it('should skip the value of a global option that takes a value', () => {
-    // The value 'connect' after --header should not be treated as a command token
-    // that stops validation; it's the header value. Then --bad should be caught.
-    expect(() => validateOptions(['--header', '--bad'])).not.toThrow();
-    // --header consumes the next arg as its value, so --bad is skipped
-    // Actually, --header takes one value, then --bad is the next token and is checked
-    // Let me verify: --header takes 'val', then the loop continues
+    // --timeout takes a value, so the next token should be skipped during validation
+    expect(() => validateOptions(['--timeout', '30', 'connect'])).not.toThrow();
+    // --profile takes a value, so the next token should be skipped
+    expect(() => validateOptions(['--profile', 'myprofile', 'connect'])).not.toThrow();
   });
 
   it('should handle --option=value syntax', () => {


### PR DESCRIPTION
## Summary
Refactored the `--header` / `-H` option to be specific to the `connect` command instead of a global option. This improves the CLI's usability by only showing relevant options for each command context.

## Key Changes
- Removed `--header` and `-H` from the top-level program options in `createTopLevelProgram()`
- Added `--header` option specifically to the `connect` command in `createConnectCommand()`
- Removed `--header` from the session program options in `createSessionProgram()`
- Removed header extraction logic from the global `extractOptions()` function
- Updated `getOptionsFromCommand()` to no longer process headers from global options
- Added header extraction logic directly in the `connect` command handler to parse headers from connect-specific options
- Moved `-H` and `--header` from `GLOBAL_OPTIONS_WITH_VALUES` to `OPTIONS_WITH_VALUES` to maintain proper argument parsing during validation

## Implementation Details
- Headers are now extracted only when the `connect` command is executed, using the command's local options object
- The header extraction logic handles both single and repeated header values consistently
- Updated validation tests to reflect that `--header` is no longer accepted as a global option but is accepted after the `connect` command token
- Updated unit tests to verify headers are not extracted by the global `extractOptions()` function

https://claude.ai/code/session_01HUYFFgLKKhNz5uz1vug52p