### PR TITLE
Fix logTarget to avoid printing prefix when session not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - E2E tests now run under the Bun runtime (in addition to Node.js); use `./test/e2e/run.sh --runtime bun` or `npm run test:e2e:bun`
 
 ### Fixed
+- `logTarget` no longer prints a misleading `[→ @name (HTTP)]` prefix when a session doesn't exist; only the error message is shown
 - `logging-set-level` JSON output no longer includes a `success` field; output is now `{"level":"<level>"}` consistent with the project's convention of indicating errors via exit codes
 - `--header` / `-H` option is now specific to the `connect` command instead of being shown as a global option in `mcpc --help`
 - Bridge now forwards `logging/message` notifications from the MCP server to connected clients, so `logging-set-level` actually takes effect in interactive shell sessions

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -888,8 +888,9 @@ export async function logTarget(target: string, options: LogTargetOptions): Prom
     const session = await getSession(target);
     if (session) {
       console.log(`[${formatSessionLine(session)}]\n`);
-      return;
     }
+    // Session not found - don't print anything, let the error handler show the message
+    return;
   }
 
   // For direct connections, use transportConfig if available


### PR DESCRIPTION
## Summary
Fixed `logTarget` function to prevent printing a misleading session prefix when a session doesn't exist. Now only the error message is displayed to the user.

## Changes
- Moved the early `return` statement in `logTarget` outside the `if (session)` block so it executes regardless of whether a session is found
- Added clarifying comment explaining that when a session is not found, the error handler will display the appropriate message
- This prevents the `[→ @name (HTTP)]` prefix from being printed when no session exists

## Implementation Details
The fix is a simple control flow adjustment: the `return` statement that was inside the `if (session)` block (only executing when a session exists) is now placed after the block, ensuring it always executes. This allows the error handling logic downstream to properly display error messages without the misleading session prefix being printed first.

https://claude.ai/code/session_01FLZpnvfdPy6kbPmHcarxEF