### PR TITLE
fix: Explicit --header Authorization no longer ignored when OAuth profile exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - E2E tests now run under the Bun runtime (in addition to Node.js); use `./test/e2e/run.sh --runtime bun` or `npm run test:e2e:bun`
 
 ### Fixed
+- Explicit `--header "Authorization: Bearer ..."` is no longer silently ignored when an OAuth profile exists for the same server; explicit CLI headers now take precedence over stored OAuth profiles
 - `logTarget` no longer prints a misleading `[→ @name (HTTP)]` prefix when a session doesn't exist; only the error message is shown
 - `logging-set-level` JSON output no longer includes a `success` field; output is now `{"level":"<level>"}` consistent with the project's convention of indicating errors via exit codes
 - `--header` / `-H` option is now specific to the `connect` command instead of being shown as a global option in `mcpc --help`

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -157,11 +157,22 @@ export async function connectSession(
     const serverConfig = await resolveTarget(target, options);
 
     // For HTTP targets, resolve auth profile (with helpful errors if none available)
+    // If user explicitly provided an Authorization header via --header and did NOT
+    // explicitly specify --profile, skip OAuth profile auto-detection.
+    // Explicit CLI flags should take precedence over stored profiles.
     let profileName: string | undefined;
+    const hasExplicitAuthHeader = serverConfig.headers?.Authorization !== undefined;
+    const hasExplicitProfile = options.profile !== undefined;
     if (serverConfig.url) {
-      profileName = await resolveAuthProfile(serverConfig.url, target, options.profile, {
-        sessionName: name,
-      });
+      if (hasExplicitAuthHeader && !hasExplicitProfile) {
+        logger.debug(
+          'Skipping OAuth profile auto-detection: explicit Authorization header provided via --header'
+        );
+      } else {
+        profileName = await resolveAuthProfile(serverConfig.url, target, options.profile, {
+          sessionName: name,
+        });
+      }
     }
 
     // Store headers in OS keychain (secure storage) before starting bridge


### PR DESCRIPTION
## Summary
- When a default OAuth profile existed for a server, explicit `--header "Authorization: Bearer ..."` was silently stripped and the (possibly expired) OAuth token was used instead
- Now, an explicit Authorization header via `--header` skips OAuth profile auto-detection when no `--profile` flag is specified, so CLI flags take precedence over stored profiles

### Decision table after fix

| `--header Auth` | `--profile` | Result |
|---|---|---|
| Yes | No | **Header used, OAuth profile skipped** (was broken) |
| Yes | Yes | Profile used, header stripped (explicit profile wins) |
| No | Yes | Profile used |
| No | No | Default profile auto-detected (unchanged) |

## Test plan
- [ ] With an existing OAuth profile for a server, run `mcpc connect <server> @test --header "Authorization: Bearer $TOKEN"` and verify the explicit token is used
- [ ] Without any OAuth profile, verify `--header Authorization` still works as before
- [ ] With `--profile` explicitly specified, verify the profile still takes precedence over `--header`
- [ ] Run `npm run test:unit` — all 414 tests pass
- [ ] Run `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)