### PR TITLE
Fix auth header precedence and prevent conflicting --profile/--header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--client-id` and `--client-secret` options for `mcpc login` command, for servers that don't support dynamic client registration
 - `mcpc close @session`, `mcpc restart @session`, and `mcpc shell @session` command-first syntax as alternatives to `mcpc @session close/restart/shell`
 - E2E tests now run under the Bun runtime (in addition to Node.js); use `./test/e2e/run.sh --runtime bun` or `npm run test:e2e:bun`
+- `--no-profile` option for `connect` command to skip OAuth profile auto-detection and connect anonymously
 
 ### Fixed
 - Explicit `--header "Authorization: Bearer ..."` is no longer silently ignored when a default OAuth profile exists for the same server; explicit CLI headers now take precedence over auto-detected profiles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,15 +401,23 @@ mcpc connect <server> @<name> --profile <profile>
 
 **Authentication Behavior:**
 
+When `--header "Authorization: ..."` is provided (without `--profile`):
+- Explicit header is used, OAuth profile auto-detection is skipped entirely
+
 When `--profile <name>` is specified:
 1. Profile exists for server → Use its stored credentials; fail with error if expired/invalid
 2. Profile doesn't exist → Fail with error
+3. Cannot be combined with `--header "Authorization: ..."` (returns error)
 
-When no `--profile` is specified (uses `default` profile):
+When `--no-profile` is specified:
+- Skip all OAuth profile detection and connect anonymously (or with explicit `--header`)
+
+When no flags are specified (default):
 1. `default` profile exists for server → Use its credentials; fail with error if expired/invalid
 2. `default` profile doesn't exist → Attempt unauthenticated connection; fail with error if server requires auth
 
 On failure, the error message includes instructions on how to login. This ensures:
+- Explicit CLI flags always take precedence over stored profiles
 - Authentication only happens when user explicitly calls `login`
 - Credentials are never silently downgraded
 - You can mix authenticated sessions and public access on the same server

--- a/README.md
+++ b/README.md
@@ -436,7 +436,16 @@ When multiple authentication methods are available, `mcpc` uses this precedence 
 3. **Config file headers** - Headers from `--config` file for the server
 4. **No authentication** - Attempts unauthenticated connection
 
-`mcpc` automatically handles authentication based on whether you specify a profile:
+**Note:** `--profile` and `--header "Authorization: ..."` cannot be combined — they are mutually
+exclusive. Providing both will result in a clear error. Use one or the other.
+
+`mcpc` automatically handles authentication based on what you specify:
+
+**When `--header "Authorization: ..."` is provided:**
+
+- The explicit header is always used, and OAuth profile auto-detection is skipped entirely
+- This works even if a `default` profile exists for the server
+- Cannot be combined with `--profile` (returns an error)
 
 **When `--profile <name>` is specified:**
 
@@ -445,7 +454,13 @@ When multiple authentication methods are available, `mcpc` uses this precedence 
    - If authentication fails (expired/invalid) → Fail with an error
 2. **Profile doesn't exist**: Fail with an error
 
-**When no `--profile` is specified:**
+**When `--no-profile` is specified:**
+
+- Skip all OAuth profile detection and connect anonymously
+- Useful when a `default` profile exists but you want an unauthenticated session
+- Can be combined with `--header "Authorization: ..."` for explicit bearer token without profile
+
+**When no flags are specified (default):**
 
 1. **`default` profile exists for the server**: Use its stored credentials
    - If authentication succeeds → Continue with command/session
@@ -458,7 +473,7 @@ On failure, the error message includes instructions on how to login and save the
 
 This flow ensures:
 
-- You only authenticate when necessary
+- Explicit CLI flags always take precedence over stored profiles
 - Credentials are never silently mixed up (personal → work) or downgraded (authenticated → unauthenticated)
 - You can mix authenticated sessions (with named profiles) and public access on the same server
 
@@ -475,6 +490,12 @@ mcpc connect mcp.apify.com @apify-work --profile work
 # - Tries unauthenticated if 'default' doesn't exist
 # - Fails if the server requires authentication
 mcpc connect mcp.apify.com @apify-personal
+
+# Explicit bearer token - skips profile auto-detection:
+mcpc connect mcp.apify.com @apify --header "Authorization: Bearer ${APIFY_TOKEN}"
+
+# Anonymous - skips default profile even if it exists:
+mcpc connect mcp.apify.com @apify-anon --no-profile
 ```
 
 ## MCP proxy

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -83,6 +83,7 @@ export async function connectSession(
     headers?: string[];
     timeout?: number;
     profile?: string;
+    noProfile?: boolean;
     proxy?: string;
     proxyBearerToken?: string;
     x402?: boolean;
@@ -170,11 +171,14 @@ export async function connectSession(
     }
 
     // For HTTP targets, resolve auth profile (with helpful errors if none available)
-    // If user explicitly provided an Authorization header via --header (and did NOT
-    // specify --profile), skip OAuth profile auto-detection so the header takes precedence.
+    // Skip OAuth profile resolution when:
+    // - --no-profile is specified (explicit anonymous connection)
+    // - --header "Authorization: ..." is provided (explicit bearer token)
     let profileName: string | undefined;
     if (serverConfig.url) {
-      if (hasExplicitAuthHeader) {
+      if (options.noProfile) {
+        logger.debug('Skipping OAuth profile: --no-profile specified');
+      } else if (hasExplicitAuthHeader) {
         logger.debug(
           'Skipping OAuth profile auto-detection: explicit Authorization header provided via --header'
         );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -60,6 +60,7 @@ interface HandlerOptions {
   timeout?: number;
   verbose?: boolean;
   profile?: string;
+  noProfile?: boolean;
   x402?: boolean;
   insecure?: boolean;
   schema?: string;
@@ -97,7 +98,11 @@ function getOptionsFromCommand(command: Command): HandlerOptions {
     }
     options.timeout = timeout;
   }
-  if (opts.profile) options.profile = opts.profile;
+  if (opts.profile === false) {
+    options.noProfile = true;
+  } else if (opts.profile) {
+    options.profile = opts.profile;
+  }
   if (verbose) options.verbose = verbose;
   if (opts.x402) options.x402 = true;
   if (opts.insecure) options.insecure = true;
@@ -353,6 +358,7 @@ Full docs: ${docsUrl}`
     .description('Connect to an MCP server and start a new named @session')
     .option('-H, --header <header>', 'HTTP header (can be repeated)')
     .option('--profile <name>', 'OAuth profile to use ("default" if skipped)')
+    .option('--no-profile', 'Skip OAuth profile (connect anonymously)')
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--x402', 'Enable x402 auto-payment using the configured wallet')

--- a/test/e2e/suites/basic/auth-header-precedence.test.sh
+++ b/test/e2e/suites/basic/auth-header-precedence.test.sh
@@ -5,6 +5,7 @@
 # 1. Explicit --header "Authorization: Bearer ..." takes precedence over auto-detected default profile
 # 2. Combining --profile with --header "Authorization: ..." returns a clear error
 # 3. --header with non-Authorization headers still works alongside profiles
+# 4. --no-profile skips auto-detected OAuth profile (anonymous connection)
 
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "basic/auth-header-precedence" --isolated
@@ -88,6 +89,48 @@ test_case "no auth header and no profile fails on auth-required server"
 # that our auth-header session from test 1 still works
 run_mcpc "$SESSION" ping
 assert_success
+test_pass
+
+# =============================================================================
+# Test 5: --no-profile skips auto-detected profile (anonymous connection)
+# =============================================================================
+# The test server requires auth, so --no-profile without an Authorization header
+# should fail with auth error (not with a profile-related error).
+
+test_case "--no-profile skips OAuth profile and connects anonymously"
+SESSION5=$(session_name "no-prof")
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION5" --no-profile
+# Session creation itself may succeed (just stores config), but the bridge
+# should fail to connect because no auth is provided to an auth-required server.
+# The key assertion: no "profile" related error, just an auth/connection failure.
+if [[ $EXIT_CODE -ne 0 ]]; then
+  assert_not_contains "$STDERR" "No default authentication profile"
+fi
+test_pass
+
+# =============================================================================
+# Test 6: --no-profile combined with --header Authorization works
+# =============================================================================
+
+# Brief pause to avoid lock contention from rapid session creation
+sleep 1
+
+test_case "--no-profile with explicit Authorization header works"
+SESSION6=$(session_name "no-prof-hdr")
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION6" \
+  --no-profile \
+  --header "Authorization: Bearer test-token-noprof"
+assert_success
+_SESSIONS_CREATED+=("$SESSION6")
+
+wait_for "$MCPC $SESSION6 ping >/dev/null 2>&1"
+run_mcpc "$SESSION6" tools-list
+assert_success
+assert_contains "$STDOUT" "echo"
+
+# Clean up
+run_mcpc "$SESSION6" close 2>/dev/null || true
+_SESSIONS_CREATED=("${_SESSIONS_CREATED[@]/$SESSION6}")
 test_pass
 
 # Clean up


### PR DESCRIPTION
## Summary
This PR fixes authentication header handling in the `connect` command to ensure explicit `--header "Authorization: ..."` flags take precedence over auto-detected OAuth profiles, and prevents conflicting combinations of `--profile` and `--header "Authorization: ..."`.

## Key Changes

- **Auth header precedence**: When a user explicitly provides `--header "Authorization: Bearer ..."`, the CLI now skips OAuth profile auto-detection entirely, allowing the explicit header to take precedence over any default profile that might exist for the server.

- **Conflict detection**: Added validation to detect and reject the mutually exclusive combination of `--profile` and `--header "Authorization: ..."`, returning a clear error message explaining the two valid alternatives.

- **Simplified header storage**: Removed the logic that conditionally stripped Authorization headers when a profile was present. Headers are now stored as-is, with the conflict check preventing problematic combinations upfront.

- **Comprehensive test coverage**: Added `auth-header-precedence.test.sh` with four test cases covering:
  - Explicit Authorization header takes precedence over default profile
  - `--profile` + `--header "Authorization: ..."` returns a clear error (both text and JSON formats)
  - Non-Authorization headers work fine alongside profiles
  - Sessions with explicit auth headers function correctly

## Implementation Details

The fix is implemented in `src/cli/commands/sessions.ts` in the `connectSession` function:
1. Detects if an Authorization header was explicitly provided via `--header` flag
2. Detects if `--profile` was explicitly specified
3. Throws a `ClientError` if both are present, with guidance on which approach to use
4. Skips OAuth profile auto-detection when an explicit Authorization header is provided
5. Stores headers without special-casing Authorization headers (the conflict check prevents problematic scenarios)

https://claude.ai/code/session_016sDR5PmmuDeiwiVDWr5ymi