### PR TITLE
Add randomized exponential backoff to file lock retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-profile` option for `connect` command to skip OAuth profile auto-detection and connect anonymously
 
 ### Fixed
+- File lock retries now use randomized exponential backoff to reduce contention when multiple processes compete for the same lock
 - Explicit `--header "Authorization: Bearer ..."` is no longer silently ignored when a default OAuth profile exists for the same server; explicit CLI headers now take precedence over auto-detected profiles
 - Combining `--profile` with `--header "Authorization: ..."` now returns a clear error instead of silently stripping the header
 - `logTarget` no longer prints a misleading `[→ @name (HTTP)]` prefix when a session doesn't exist; only the error message is shown

--- a/src/lib/file-lock.ts
+++ b/src/lib/file-lock.ts
@@ -45,6 +45,7 @@ export async function withFileLock<T>(
         retries: 5,
         minTimeout: 100,
         maxTimeout: LOCK_TIMEOUT,
+        randomize: true,
       },
     });
 


### PR DESCRIPTION
## Summary
Improved file lock retry mechanism by enabling randomized exponential backoff to reduce contention when multiple processes compete for the same lock.

## Changes
- Enabled the `randomize` option in the retry configuration for `withFileLock()` function
- This causes retry delays to be randomized within the exponential backoff range, preventing thundering herd scenarios where multiple processes retry simultaneously

## Implementation Details
The change modifies the retry strategy in `src/lib/file-lock.ts` by setting `randomize: true` in the retry options. Combined with the existing `minTimeout: 100` and `maxTimeout: LOCK_TIMEOUT` settings, this ensures that when multiple processes are waiting for a lock, their retry attempts are staggered randomly rather than synchronized, significantly reducing lock contention and improving overall system performance.

https://claude.ai/code/session_01BBeekEng72MXvQWWnPZohs