### PR TITLE
Configure minimum release age for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary
Updated the Renovate configuration to enforce a minimum release age requirement before dependencies are automatically updated.

## Changes
- Added `minimumReleaseAge` setting with a value of 7 days to the Renovate configuration
- This ensures that newly released package versions must be available for at least 7 days before Renovate will consider updating to them

## Details
This configuration change helps reduce the risk of updating to unstable or problematic releases by waiting for a grace period after a package is published. This is a common best practice to allow time for the community to identify and report any issues with new releases before they are automatically adopted.

https://claude.ai/code/session_011iBXh66ytcSF53naecov9A