### PR TITLE
Add installation instructions to release workflow summaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,17 @@ jobs:
 
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "### Pre-release version: \`$NEW_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          PKG_NAME=$(node -p "require('./package.json').name")
+          {
+            echo "### Pre-release version: \`$NEW_VERSION\`"
+            echo ""
+            echo "#### Install"
+            echo "\`\`\`bash"
+            echo "npm install -g ${PKG_NAME}@${NEW_VERSION}"
+            echo "# or"
+            echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish pre-release to npm
         if: inputs.type == 'pre-release'
@@ -156,7 +166,17 @@ jobs:
 
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "### Release version: \`$NEW_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          PKG_NAME=$(node -p "require('./package.json').name")
+          {
+            echo "### Release version: \`$NEW_VERSION\`"
+            echo ""
+            echo "#### Install"
+            echo "\`\`\`bash"
+            echo "npm install -g ${PKG_NAME}@${NEW_VERSION}"
+            echo "# or"
+            echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update CHANGELOG.md
         if: inputs.type == 'release'


### PR DESCRIPTION
## Summary
Enhanced the GitHub Actions release workflow to include installation instructions in the job summaries for both pre-release and release versions.

## Key Changes
- Updated the pre-release version summary to include npm and bun installation commands
- Updated the release version summary to include npm and bun installation commands
- Both summaries now dynamically extract the package name from `package.json` and display formatted bash code blocks with installation instructions

## Implementation Details
- Added extraction of package name using `node -p "require('./package.json').name"`
- Used multi-line echo statements with proper formatting (code blocks, headers, and spacing) to create more informative step summaries
- Installation instructions support both npm and bun package managers
- The changes maintain consistency between pre-release and release workflow steps

https://claude.ai/code/session_01MLvG2cs99K4gj97Zpj52t5