### PR TITLE
Remove redundant success field from logging set-level JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `--timeout` flag now correctly propagates to MCP requests via session bridge
 - `parseServerArg()` now handles well Windows drive-letter config paths as well as other ambiguous cases
+- `logging-set-level` JSON output no longer includes redundant `success` field
 
 ### Changed
 - **Breaking:** CLI syntax redesigned to command-first style. All commands now start with a verb; MCP operations require a named session.

--- a/src/cli/commands/logging.ts
+++ b/src/cli/commands/logging.ts
@@ -40,15 +40,7 @@ export async function setLogLevel(
     if (options.outputMode === 'human') {
       console.log(formatSuccess(`Server log level set to: ${level}`));
     } else {
-      console.log(
-        formatOutput(
-          {
-            level,
-            success: true,
-          },
-          'json'
-        )
-      );
+      console.log(formatOutput({ level }, 'json'));
     }
   });
 }


### PR DESCRIPTION
## Summary
Simplified the JSON output format for the `logging-set-level` command by removing the redundant `success` field. The output now only includes the `level` field, making the response more concise and focused.

## Changes
- Removed the `success: true` field from the JSON output in `setLogLevel()` command
- Updated the `formatOutput()` call to only include the `level` property
- Updated CHANGELOG.md to document this fix

## Details
The `success` field was redundant in the JSON response since the command either succeeds (and returns the output) or fails (and throws an error). By removing this field, the JSON output is now cleaner and more aligned with REST API conventions where the presence of a successful response implies success.

https://claude.ai/code/session_01RgrSu5dW8zFrroHJLjCUdZ