### PR TITLE
Fix auth loss when reconnecting unauthorized sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed auth loss when reconnecting an unauthorized session via `mcpc connect` — the `unauthorized` status was not cleared, causing all subsequent operations to fail with "Authentication required by server" even after successful reconnection
+
 ### Changed
 
 - **Breaking:** CLI syntax redesigned to command-first style. All commands now start with a verb; MCP operations require a named session.

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -233,6 +233,8 @@ export async function connectSession(
     ...(proxyConfig && { proxy: proxyConfig }),
     ...(options.x402 && { x402: true }),
     ...(options.insecure && { insecure: true }),
+    // Clear any previous error status (unauthorized, expired) when reconnecting
+    ...(isReconnect && { status: 'active' }),
   };
 
   if (isReconnect) {


### PR DESCRIPTION
## Summary
Fixed an issue where reconnecting an unauthorized session via `mcpc connect` would fail with "Authentication required by server" even after successful reconnection. The `unauthorized` status was not being cleared during reconnection, causing all subsequent operations to fail.

## Changes
- Clear the `status` field when reconnecting a session, resetting it to `'active'` state
- This ensures that previous error statuses (unauthorized, expired, etc.) don't persist after a successful reconnection
- Added clarifying comment explaining the purpose of the status reset

## Implementation Details
The fix is minimal and surgical: when `isReconnect` is true, the session configuration now explicitly sets `status: 'active'` to override any previous error state. This allows the reconnection to proceed cleanly without being blocked by stale authentication errors.

https://claude.ai/code/session_014EiYUjqZVMENeNqPiarPkC