### PR TITLE
Add E2E test prerequisites to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,27 @@ npm run test:e2e            # Run e2e tests only
 npm run test:coverage       # Run all tests with coverage
 ```
 
+### E2E test prerequisites
+
+E2E tests require `mcpc` to be built first:
+
+```bash
+npm run build
+npm link
+```
+
+Some E2E tests connect to a real remote MCP server and require OAuth authentication profiles.
+Without these profiles, the affected tests will be skipped or fail.
+
+To set them up, [create a free Apify account](https://console.apify.com/sign-up) (you can use the same account for both profiles), then run:
+
+```bash
+mcpc login mcp.apify.com --profile e2e-test1
+mcpc login mcp.apify.com --profile e2e-test2
+```
+
+The test runner does not take any destructive actions.
+
 ## Release process
 
 Use the release script to publish a new version


### PR DESCRIPTION
## Summary
- Document build/link steps and OAuth profile setup needed to run E2E tests in CONTRIBUTING.md
- Saves contributors from discovering these requirements through test failures

## Test plan
- [x] Verified the added section is accurate against `test/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)