### PR TITLE
feat: x402 payment support — signature caching and JSON-RPC 402 retry

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -43,8 +43,13 @@ const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.j
 };
 import { ProxyServer } from './proxy-server.js';
 import type { ProxyConfig } from '../lib/types.js';
-import { createX402FetchMiddleware } from '../lib/x402/fetch-middleware.js';
-import type { SignerWallet } from '../lib/x402/signer.js';
+import {
+  createX402FetchMiddleware,
+  extractPaymentRequiredFromError,
+  extractAcceptFromErrorData,
+  type X402PaymentCache,
+} from '../lib/x402/fetch-middleware.js';
+import { signPayment, type SignerWallet } from '../lib/x402/signer.js';
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 // HTTP proxy and TLS settings are configured in main() after parsing --insecure flag
@@ -92,6 +97,9 @@ class BridgeProcess {
 
   // x402 wallet for automatic payment signing (received via IPC, stored in memory only)
   private x402Wallet: SignerWallet | null = null;
+
+  // Shared payment signature cache — middleware reads/writes, bridge invalidates on JSON-RPC 402
+  private x402PaymentCache: X402PaymentCache = { signature: null };
 
   // Active async tasks (in-memory, also persisted to disk for crash recovery)
   private activeTasks: Map<string, Task> = new Map();
@@ -534,7 +542,11 @@ class BridgeProcess {
         // McpClient caches tools in-memory after the first listAllTools call
         return this.client?.getCachedTools()?.find((t: Tool) => t.name === name);
       };
-      customFetch = createX402FetchMiddleware(proxyFetch as FetchLike, { wallet, getToolByName });
+      customFetch = createX402FetchMiddleware(proxyFetch as FetchLike, {
+        wallet,
+        getToolByName,
+        paymentCache: this.x402PaymentCache,
+      });
     }
 
     const clientConfig: CreateMcpClientOptions = {
@@ -940,6 +952,52 @@ class BridgeProcess {
   }
 
   /**
+   * Handle a JSON-RPC 402 payment required error by signing a fresh payment,
+   * caching it, and retrying the tool call once.
+   *
+   * Returns true if the error was a 402 and was handled (result set via callback).
+   * Returns false if the error is not a 402 (caller should rethrow).
+   */
+  private async handlePaymentRequiredRetry(
+    error: unknown,
+    retryFn: () => Promise<unknown>
+  ): Promise<{ handled: true; result: unknown } | { handled: false }> {
+    if (!this.x402Wallet) return { handled: false };
+
+    const errorData = extractPaymentRequiredFromError(error);
+    if (!errorData) return { handled: false };
+
+    const parsed = extractAcceptFromErrorData(errorData);
+    if (!parsed) {
+      logger.warn('JSON-RPC 402 error but could not extract supported payment terms');
+      return { handled: false };
+    }
+
+    logger.debug('JSON-RPC 402 received, signing fresh payment and retrying...');
+
+    // Invalidate cache and sign fresh
+    this.x402PaymentCache.signature = null;
+    try {
+      const signed = await signPayment({
+        wallet: this.x402Wallet,
+        accept: parsed.accept,
+        resource: parsed.resource,
+      });
+      this.x402PaymentCache.signature = signed.paymentSignatureBase64;
+      logger.debug(
+        `Fresh payment signed for retry: $${signed.amountUsd.toFixed(4)} to ${signed.to} on ${signed.networkLabel}`
+      );
+    } catch (signError) {
+      logger.warn('Failed to sign fresh payment for 402 retry:', signError);
+      return { handled: false };
+    }
+
+    // Retry once with the new cached payment
+    const result = await retryFn();
+    return { handled: true, result };
+  }
+
+  /**
    * Forward an MCP request to the MCP server
    * Blocks until MCP client is connected, propagates connection errors to caller
    */
@@ -993,28 +1051,32 @@ class BridgeProcess {
             useTask?: boolean;
             detach?: boolean;
           };
-          if (params.useTask && this.client.supportsTasksForToolCall()) {
-            if (params.detach) {
-              // Detached execution: start task and return task ID immediately
-              // The tool continues running in the background on the server
-              const taskUpdate = await this.client.callToolDetached(
-                params.name,
-                params.arguments,
-                params._meta
-              );
-              this.activeTasks.set(taskUpdate.taskId, {
-                taskId: taskUpdate.taskId,
-                status: taskUpdate.status,
-                statusMessage: taskUpdate.statusMessage,
-                createdAt: taskUpdate.createdAt ?? new Date().toISOString(),
-                lastUpdatedAt: taskUpdate.lastUpdatedAt ?? new Date().toISOString(),
-              } as Task);
-              await this.persistActiveTask(taskUpdate.taskId, params.name);
-              result = taskUpdate;
-            } else {
+
+          // Helper to execute the tool call (used for initial attempt and 402 retry)
+          // Capture client ref — guaranteed non-null by check at top of handleMcpRequest
+          const client = this.client;
+          const executeToolCall = async (): Promise<unknown> => {
+            if (params.useTask && client.supportsTasksForToolCall()) {
+              if (params.detach) {
+                // Detached execution: start task and return task ID immediately
+                const taskUpdate = await client.callToolDetached(
+                  params.name,
+                  params.arguments,
+                  params._meta
+                );
+                this.activeTasks.set(taskUpdate.taskId, {
+                  taskId: taskUpdate.taskId,
+                  status: taskUpdate.status,
+                  statusMessage: taskUpdate.statusMessage,
+                  createdAt: taskUpdate.createdAt ?? new Date().toISOString(),
+                  lastUpdatedAt: taskUpdate.lastUpdatedAt ?? new Date().toISOString(),
+                } as Task);
+                await this.persistActiveTask(taskUpdate.taskId, params.name);
+                return taskUpdate;
+              }
+
               // Task-augmented tool call: stream updates to requesting socket
               const onUpdate = (update: TaskUpdate): void => {
-                // Track active task
                 this.activeTasks.set(update.taskId, {
                   taskId: update.taskId,
                   status: update.status,
@@ -1022,7 +1084,6 @@ class BridgeProcess {
                   createdAt: update.createdAt ?? new Date().toISOString(),
                   lastUpdatedAt: update.lastUpdatedAt ?? new Date().toISOString(),
                 } as Task);
-                // Send task update to requesting client
                 if (message.id) {
                   this.sendResponse(socket, {
                     type: 'task-update',
@@ -1037,14 +1098,13 @@ class BridgeProcess {
                 onUpdate(update);
               }, params.name);
               try {
-                result = await this.client.callToolWithTask(
+                return await client.callToolWithTask(
                   params.name,
                   params.arguments,
                   wrappedOnUpdate,
                   params._meta
                 );
               } finally {
-                // Clean up completed tasks from activeTasks and persistence
                 for (const [tid, task] of this.activeTasks) {
                   if (
                     task.status === 'completed' ||
@@ -1060,8 +1120,20 @@ class BridgeProcess {
                 }
               }
             }
-          } else {
-            result = await this.client.callTool(params.name, params.arguments, params._meta);
+
+            return client.callTool(params.name, params.arguments, params._meta);
+          };
+
+          // Execute with automatic 402 payment retry
+          try {
+            result = await executeToolCall();
+          } catch (error) {
+            const retry = await this.handlePaymentRequiredRetry(error, executeToolCall);
+            if (retry.handled) {
+              result = retry.result;
+            } else {
+              throw error;
+            }
           }
           break;
         }

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -45,8 +45,8 @@ import { ProxyServer } from './proxy-server.js';
 import type { ProxyConfig } from '../lib/types.js';
 import {
   createX402FetchMiddleware,
-  extractPaymentRequiredFromError,
-  extractAcceptFromErrorData,
+  extractPaymentRequiredFromResult,
+  extractAcceptFromPaymentRequired,
   type X402PaymentCache,
 } from '../lib/x402/fetch-middleware.js';
 import { signPayment, type SignerWallet } from '../lib/x402/signer.js';
@@ -98,7 +98,7 @@ class BridgeProcess {
   // x402 wallet for automatic payment signing (received via IPC, stored in memory only)
   private x402Wallet: SignerWallet | null = null;
 
-  // Shared payment signature cache — middleware reads/writes, bridge invalidates on JSON-RPC 402
+  // Shared payment signature cache — middleware reads/writes, bridge invalidates on payment-required results
   private x402PaymentCache: X402PaymentCache = { signature: null };
 
   // Active async tasks (in-memory, also persisted to disk for crash recovery)
@@ -952,28 +952,28 @@ class BridgeProcess {
   }
 
   /**
-   * Handle a JSON-RPC 402 payment required error by signing a fresh payment,
-   * caching it, and retrying the tool call once.
+   * Handle a tool result that contains x402 payment-required data.
+   * Signs a fresh payment, caches it, and retries the tool call once.
    *
-   * Returns true if the error was a 402 and was handled (result set via callback).
-   * Returns false if the error is not a 402 (caller should rethrow).
+   * Returns { handled: true, result } if payment was signed and retry succeeded.
+   * Returns { handled: false } if the result is not a payment-required response.
    */
   private async handlePaymentRequiredRetry(
-    error: unknown,
+    toolResult: unknown,
     retryFn: () => Promise<unknown>
   ): Promise<{ handled: true; result: unknown } | { handled: false }> {
     if (!this.x402Wallet) return { handled: false };
 
-    const errorData = extractPaymentRequiredFromError(error);
-    if (!errorData) return { handled: false };
+    const paymentRequired = extractPaymentRequiredFromResult(toolResult);
+    if (!paymentRequired) return { handled: false };
 
-    const parsed = extractAcceptFromErrorData(errorData);
+    const parsed = extractAcceptFromPaymentRequired(paymentRequired);
     if (!parsed) {
-      logger.warn('JSON-RPC 402 error but could not extract supported payment terms');
+      logger.warn('Payment-required tool result but could not extract supported payment terms');
       return { handled: false };
     }
 
-    logger.debug('JSON-RPC 402 received, signing fresh payment and retrying...');
+    logger.debug('Payment-required tool result received, signing fresh payment and retrying...');
 
     // Invalidate cache and sign fresh
     this.x402PaymentCache.signature = null;
@@ -1124,16 +1124,11 @@ class BridgeProcess {
             return client.callTool(params.name, params.arguments, params._meta);
           };
 
-          // Execute with automatic 402 payment retry
-          try {
-            result = await executeToolCall();
-          } catch (error) {
-            const retry = await this.handlePaymentRequiredRetry(error, executeToolCall);
-            if (retry.handled) {
-              result = retry.result;
-            } else {
-              throw error;
-            }
+          // Execute with automatic x402 payment retry on payment-required tool results
+          result = await executeToolCall();
+          const retry = await this.handlePaymentRequiredRetry(result, executeToolCall);
+          if (retry.handled) {
+            result = retry.result;
           }
           break;
         }

--- a/src/lib/x402/fetch-middleware.ts
+++ b/src/lib/x402/fetch-middleware.ts
@@ -2,12 +2,16 @@
  * x402 fetch middleware for MCP transport
  *
  * Wraps the fetch function used by StreamableHTTPClientTransport to:
- * 1. Proactively sign payments when tool metadata includes _meta.x402
- * 2. Handle HTTP 402 responses by parsing PAYMENT-REQUIRED, signing, and retrying once
+ * 1. Reuse a cached payment signature across tool calls within a session
+ * 2. Sign a fresh payment on the first call (or after cache invalidation)
+ * 3. Handle HTTP 402 responses by parsing PAYMENT-REQUIRED, signing, and retrying once
  *
  * Payment is injected in two places simultaneously (server decides which to use):
  * - HTTP header: PAYMENT-SIGNATURE (base64-encoded payment payload)
  * - JSON-RPC body: params._meta["x402/payment"] (payment payload object)
+ *
+ * The cache is shared with the bridge layer, which invalidates it on JSON-RPC 402
+ * errors and signs a fresh payment before retrying the tool call.
  *
  * This middleware is injected into the transport via the SDK's `fetch` option.
  */
@@ -51,6 +55,15 @@ interface JsonRpcRequest {
 }
 
 /**
+ * Shared mutable cache for payment signatures between the fetch middleware and the bridge.
+ * The middleware reads and writes cached signatures; the bridge invalidates on JSON-RPC 402.
+ */
+export interface X402PaymentCache {
+  /** Base64-encoded payment signature, or null if not yet signed / invalidated */
+  signature: string | null;
+}
+
+/**
  * Options for creating the x402 fetch middleware
  */
 export interface X402FetchMiddlewareOptions {
@@ -63,6 +76,9 @@ export interface X402FetchMiddlewareOptions {
    * This is called per tools/call request for proactive signing.
    */
   getToolByName?: (name: string) => Tool | undefined;
+
+  /** Shared mutable cache for reusing payment signatures across tool calls */
+  paymentCache: X402PaymentCache;
 }
 
 /**
@@ -77,32 +93,32 @@ export function createX402FetchMiddleware(
   baseFetch: FetchLike,
   options: X402FetchMiddlewareOptions
 ): FetchLike {
-  const { wallet, getToolByName } = options;
+  const { wallet, getToolByName, paymentCache } = options;
 
   return async (url: string | URL, init?: RequestInit): Promise<Response> => {
-    // Try proactive signing for tools/call requests
-    const proactiveHeader = await tryProactiveSigning(init, wallet, getToolByName);
-    if (proactiveHeader) {
-      logger.debug('Proactively signing x402 payment for tools/call');
-      const enhancedInit = injectPayment(init, proactiveHeader);
+    // Try to get a payment signature (cached or freshly signed) for tools/call requests
+    const paymentSignature = await getOrSignPayment(init, wallet, getToolByName, paymentCache);
+    if (paymentSignature) {
+      const enhancedInit = injectPayment(init, paymentSignature);
       const response = await baseFetch(url, enhancedInit);
 
-      // If proactive signing succeeded (not 402), return immediately
+      // If payment succeeded (not HTTP 402), return immediately
       if (response.status !== 402) {
         return response;
       }
 
-      // Proactive signing failed with 402 — fall through to 402 fallback
-      logger.debug('Proactive payment rejected (402), falling back to 402 handler');
-      return handle402Fallback(url, init, response, baseFetch, wallet);
+      // HTTP 402 — invalidate cache and fall through to fallback
+      logger.debug('Payment rejected (HTTP 402), invalidating cache');
+      paymentCache.signature = null;
+      return handle402Fallback(url, init, response, baseFetch, wallet, paymentCache);
     }
 
-    // No proactive signing — make request normally
+    // No payment needed — make request normally
     const response = await baseFetch(url, init);
 
-    // Check for 402 fallback
+    // Check for HTTP 402 fallback
     if (response.status === 402) {
-      return handle402Fallback(url, init, response, baseFetch, wallet);
+      return handle402Fallback(url, init, response, baseFetch, wallet, paymentCache);
     }
 
     return response;
@@ -110,13 +126,15 @@ export function createX402FetchMiddleware(
 }
 
 /**
- * Try to proactively sign a payment based on tool metadata.
- * Returns the base64-encoded PAYMENT-SIGNATURE header, or undefined if not applicable.
+ * Get a cached payment signature or sign a fresh one for a tools/call request.
+ * Returns the base64-encoded PAYMENT-SIGNATURE, or undefined if the request
+ * is not a tools/call for a payment-required tool.
  */
-async function tryProactiveSigning(
+async function getOrSignPayment(
   init: RequestInit | undefined,
   wallet: SignerWallet,
-  getToolByName?: (name: string) => Tool | undefined
+  getToolByName: ((name: string) => Tool | undefined) | undefined,
+  paymentCache: X402PaymentCache
 ): Promise<string | undefined> {
   if (!getToolByName || !init?.body) {
     return undefined;
@@ -136,7 +154,7 @@ async function tryProactiveSigning(
   // Look up tool metadata
   const tool = getToolByName(toolName);
   if (!tool) {
-    logger.debug(`Tool "${toolName}" not found in cache, skipping proactive signing`);
+    logger.debug(`Tool "${toolName}" not found in cache, skipping payment`);
     return undefined;
   }
 
@@ -147,15 +165,21 @@ async function tryProactiveSigning(
     return undefined;
   }
 
-  // Check if we have enough info to sign proactively
+  // Return cached signature if available
+  if (paymentCache.signature) {
+    logger.debug(`Using cached payment signature for tool "${toolName}"`);
+    return paymentCache.signature;
+  }
+
+  // Check if we have enough info to sign
   if (!x402.scheme || !x402.network || !x402.amount || !x402.asset || !x402.payTo) {
     logger.debug(
-      `Tool "${toolName}" has x402 metadata but missing fields, skipping proactive signing`
+      `Tool "${toolName}" has x402 metadata but missing fields, skipping payment signing`
     );
     return undefined;
   }
 
-  // Build accept from tool metadata
+  // Build accept from tool metadata and sign fresh
   const accept: PaymentRequiredAccept = {
     scheme: x402.scheme,
     network: x402.network,
@@ -169,24 +193,27 @@ async function tryProactiveSigning(
   try {
     const result = await signPayment({ wallet, accept });
     logger.debug(
-      `Proactive payment signed: $${result.amountUsd.toFixed(4)} to ${result.to} on ${result.networkLabel}`
+      `Fresh payment signed: $${result.amountUsd.toFixed(4)} to ${result.to} on ${result.networkLabel}`
     );
+    paymentCache.signature = result.paymentSignatureBase64;
     return result.paymentSignatureBase64;
   } catch (error) {
-    logger.warn(`Proactive signing failed for tool "${toolName}":`, error);
+    logger.warn(`Payment signing failed for tool "${toolName}":`, error);
     return undefined;
   }
 }
 
 /**
  * Handle a 402 response by parsing PAYMENT-REQUIRED, signing, and retrying once.
+ * Also updates the payment cache with the freshly signed payment.
  */
 async function handle402Fallback(
   url: string | URL,
   originalInit: RequestInit | undefined,
   response402: Response,
   baseFetch: FetchLike,
-  wallet: SignerWallet
+  wallet: SignerWallet,
+  paymentCache: X402PaymentCache
 ): Promise<Response> {
   // Extract PAYMENT-REQUIRED header (case-insensitive)
   const paymentRequiredBase64 =
@@ -219,6 +246,9 @@ async function handle402Fallback(
     logger.debug(
       `402 fallback payment signed: $${result.amountUsd.toFixed(4)} to ${result.to} on ${result.networkLabel}`
     );
+
+    // Cache the freshly signed payment for subsequent calls
+    paymentCache.signature = result.paymentSignatureBase64;
 
     // Retry with payment signature (once only)
     const retryInit = injectPayment(originalInit, result.paymentSignatureBase64);
@@ -261,6 +291,73 @@ function extractToolCallName(body: RequestInit['body'] | undefined): string | un
   } catch {
     return undefined;
   }
+}
+
+/** JSON-RPC error code for x402 payment required */
+const MCP_PAYMENT_REQUIRED_CODE = 402;
+
+/**
+ * Extract `PaymentRequiredAccept` from a JSON-RPC 402 error's data field.
+ * Returns the first "exact" scheme accept entry, or undefined if not found.
+ *
+ * The error data is expected to have the shape: `{ x402Version, accepts: [...] }`
+ */
+export function extractAcceptFromErrorData(errorData: unknown):
+  | {
+      accept: PaymentRequiredAccept;
+      resource?: { url?: string; description?: string; mimeType?: string };
+    }
+  | undefined {
+  if (!errorData || typeof errorData !== 'object') return undefined;
+
+  const data = errorData as Record<string, unknown>;
+  if (!Array.isArray(data.accepts) || data.accepts.length === 0) return undefined;
+
+  const accept = (data.accepts as PaymentRequiredAccept[]).find((a) => a.scheme === 'exact');
+  if (!accept || !accept.payTo || !accept.amount || !accept.network || !accept.asset) {
+    return undefined;
+  }
+
+  const resource = data.resource as
+    | { url?: string; description?: string; mimeType?: string }
+    | undefined;
+  if (resource) {
+    return { accept, resource };
+  }
+  return { accept };
+}
+
+/**
+ * Check if an error from the MCP SDK is a JSON-RPC 402 payment required error.
+ * Returns the error data if it is, undefined otherwise.
+ *
+ * The SDK throws McpError with `.code` and `.data` properties.
+ * McpClient wraps it as ServerError with `{ originalError: sdkError }`.
+ */
+export function extractPaymentRequiredFromError(
+  error: unknown
+): Record<string, unknown> | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+
+  // Check if this is a ServerError wrapping an SDK McpError
+  const details = (error as { details?: unknown }).details;
+  if (details && typeof details === 'object') {
+    const originalError = (details as { originalError?: unknown }).originalError;
+    if (originalError && typeof originalError === 'object') {
+      const sdkError = originalError as { code?: number; data?: unknown };
+      if (sdkError.code === MCP_PAYMENT_REQUIRED_CODE && sdkError.data) {
+        return sdkError.data as Record<string, unknown>;
+      }
+    }
+  }
+
+  // Also check if the error itself has code/data (direct SDK error)
+  const directError = error as { code?: number; data?: unknown };
+  if (directError.code === MCP_PAYMENT_REQUIRED_CODE && directError.data) {
+    return directError.data as Record<string, unknown>;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/lib/x402/fetch-middleware.ts
+++ b/src/lib/x402/fetch-middleware.ts
@@ -10,8 +10,8 @@
  * - HTTP header: PAYMENT-SIGNATURE (base64-encoded payment payload)
  * - JSON-RPC body: params._meta["x402/payment"] (payment payload object)
  *
- * The cache is shared with the bridge layer, which invalidates it on JSON-RPC 402
- * errors and signs a fresh payment before retrying the tool call.
+ * The cache is shared with the bridge layer, which invalidates it when the server
+ * returns a payment-required tool result and signs a fresh payment before retrying.
  *
  * This middleware is injected into the transport via the SDK's `fetch` option.
  */
@@ -293,32 +293,29 @@ function extractToolCallName(body: RequestInit['body'] | undefined): string | un
   }
 }
 
-/** JSON-RPC error code for x402 payment required */
-const MCP_PAYMENT_REQUIRED_CODE = 402;
-
 /**
- * Extract `PaymentRequiredAccept` from a JSON-RPC 402 error's data field.
+ * Extract `PaymentRequiredAccept` from a PaymentRequired object.
  * Returns the first "exact" scheme accept entry, or undefined if not found.
  *
- * The error data is expected to have the shape: `{ x402Version, accepts: [...] }`
+ * The data is expected to have the shape: `{ x402Version, accepts: [...] }`
  */
-export function extractAcceptFromErrorData(errorData: unknown):
+export function extractAcceptFromPaymentRequired(data: unknown):
   | {
       accept: PaymentRequiredAccept;
       resource?: { url?: string; description?: string; mimeType?: string };
     }
   | undefined {
-  if (!errorData || typeof errorData !== 'object') return undefined;
+  if (!data || typeof data !== 'object') return undefined;
 
-  const data = errorData as Record<string, unknown>;
-  if (!Array.isArray(data.accepts) || data.accepts.length === 0) return undefined;
+  const obj = data as Record<string, unknown>;
+  if (!Array.isArray(obj.accepts) || obj.accepts.length === 0) return undefined;
 
-  const accept = (data.accepts as PaymentRequiredAccept[]).find((a) => a.scheme === 'exact');
+  const accept = (obj.accepts as PaymentRequiredAccept[]).find((a) => a.scheme === 'exact');
   if (!accept || !accept.payTo || !accept.amount || !accept.network || !accept.asset) {
     return undefined;
   }
 
-  const resource = data.resource as
+  const resource = obj.resource as
     | { url?: string; description?: string; mimeType?: string }
     | undefined;
   if (resource) {
@@ -327,37 +324,69 @@ export function extractAcceptFromErrorData(errorData: unknown):
   return { accept };
 }
 
-/**
- * Check if an error from the MCP SDK is a JSON-RPC 402 payment required error.
- * Returns the error data if it is, undefined otherwise.
- *
- * The SDK throws McpError with `.code` and `.data` properties.
- * McpClient wraps it as ServerError with `{ originalError: sdkError }`.
- */
-export function extractPaymentRequiredFromError(
-  error: unknown
-): Record<string, unknown> | undefined {
-  if (!error || typeof error !== 'object') return undefined;
+/** Content item from MCP tool result */
+interface ToolResultContent {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
 
-  // Check if this is a ServerError wrapping an SDK McpError
-  const details = (error as { details?: unknown }).details;
-  if (details && typeof details === 'object') {
-    const originalError = (details as { originalError?: unknown }).originalError;
-    if (originalError && typeof originalError === 'object') {
-      const sdkError = originalError as { code?: number; data?: unknown };
-      if (sdkError.code === MCP_PAYMENT_REQUIRED_CODE && sdkError.data) {
-        return sdkError.data as Record<string, unknown>;
-      }
-    }
+/** Shape of an MCP tool call result */
+interface ToolCallResult {
+  content?: ToolResultContent[];
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Check if a tool call result is an x402 payment-required response.
+ * Returns the PaymentRequired data if found, undefined otherwise.
+ *
+ * Per the x402 MCP transport spec, payment required is signaled as a tool result with:
+ * - isError: true
+ * - structuredContent containing { x402Version, accepts: [...] } (preferred)
+ * - OR content[0].text as JSON-encoded PaymentRequired (fallback)
+ */
+export function extractPaymentRequiredFromResult(
+  result: unknown
+): Record<string, unknown> | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+
+  const toolResult = result as ToolCallResult;
+  if (!toolResult.isError) return undefined;
+
+  // Path 1: structuredContent (preferred)
+  if (toolResult.structuredContent && isPaymentRequired(toolResult.structuredContent)) {
+    return toolResult.structuredContent;
   }
 
-  // Also check if the error itself has code/data (direct SDK error)
-  const directError = error as { code?: number; data?: unknown };
-  if (directError.code === MCP_PAYMENT_REQUIRED_CODE && directError.data) {
-    return directError.data as Record<string, unknown>;
+  // Path 2: content[0].text as JSON (fallback)
+  const content = toolResult.content;
+  if (!Array.isArray(content) || content.length === 0) return undefined;
+
+  const first = content[0] as ToolResultContent | undefined;
+  if (!first || first.type !== 'text' || typeof first.text !== 'string') return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(first.text);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      isPaymentRequired(parsed as Record<string, unknown>)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not JSON
   }
 
   return undefined;
+}
+
+/** Check if an object looks like a PaymentRequired (has x402Version + accepts array) */
+function isPaymentRequired(obj: Record<string, unknown>): boolean {
+  return 'x402Version' in obj && 'accepts' in obj && Array.isArray(obj.accepts);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Cache x402 payment signature at session level, reuse across all tool calls in a session
- Detect x402 payment-required tool results (per x402 MCP transport spec) and auto-retry with fresh payment
- Inject payment in both `PAYMENT-SIGNATURE` HTTP header and `params._meta["x402/payment"]` JSON-RPC body

## How it works
1. First tool call: middleware signs a fresh x402 payment using the tool's `_meta.x402` metadata, caches it
2. Subsequent calls: reuse the cached signature (acts as prepaid balance session key)
3. On payment-required tool result (`isError: true` + `structuredContent` with `x402Version`/`accepts`): bridge invalidates cache, signs fresh from the `accepts` array, retries once
4. HTTP 402 fallback: fetch middleware also handles raw HTTP 402 responses with `PAYMENT-REQUIRED` header

## x402 MCP transport spec compatibility
Payment-required responses follow the x402 MCP transport spec used by `@x402/mcp`:
- Server returns a tool result with `isError: true`
- `structuredContent` contains the `PaymentRequired` object (`x402Version`, `accepts`, `resource`)
- `content[0].text` contains the same as JSON string (fallback)
- Client detects via `extractPaymentRequiredFromResult`, NOT via JSON-RPC error codes