### PR TITLE
feat: Add QR code display for wallet addresses in x402 commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- QR code display for wallet address in `x402 init`, `x402 import`, and `x402 info` commands, allowing users to scan and fund the wallet directly from the terminal
+
 ### Changed
 
 - Release process migrated from local `scripts/publish.sh` to GitHub Actions; `npm run release` now triggers the CI workflow instead of running locally

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "commander": "^14.0.2",
         "ora": "^9.0.0",
         "proper-lockfile": "^4.1.2",
+        "qrcode-terminal": "^0.12.0",
         "undici": "^7.22.0",
         "uuid": "^13.0.0",
         "viem": "^2.46.3"
@@ -29,6 +30,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^25.0.3",
         "@types/proper-lockfile": "^4.1.4",
+        "@types/qrcode-terminal": "^0.12.2",
         "@types/uuid": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
         "@typescript-eslint/parser": "^8.50.0",
@@ -2765,6 +2767,13 @@
       "dependencies": {
         "@types/retry": "*"
       }
+    },
+    "node_modules/@types/qrcode-terminal": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/qrcode-terminal/-/qrcode-terminal-0.12.2.tgz",
+      "integrity": "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.5",
@@ -10821,6 +10830,14 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "commander": "^14.0.2",
     "ora": "^9.0.0",
     "proper-lockfile": "^4.1.2",
+    "qrcode-terminal": "^0.12.0",
     "undici": "^7.22.0",
     "uuid": "^13.0.0",
     "viem": "^2.46.3"
@@ -70,6 +71,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
     "@types/proper-lockfile": "^4.1.4",
+    "@types/qrcode-terminal": "^0.12.2",
     "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -4,6 +4,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import qrcode from 'qrcode-terminal';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import type { Hex } from 'viem';
 import { formatSuccess, formatError, formatInfo, formatJson } from '../output.js';
@@ -17,6 +18,32 @@ import { signPayment, parsePaymentRequired } from '../../lib/x402/signer.js';
 // ---------------------------------------------------------------------------
 
 const USDC_DECIMALS = 6;
+
+/**
+ * Generate a QR code string for the given text using small (half-block) mode.
+ */
+function generateQrCode(text: string): Promise<string> {
+  return new Promise((resolve) => {
+    qrcode.generate(text, { small: true }, (code) => {
+      resolve(code);
+    });
+  });
+}
+
+/**
+ * Print a QR code for an Ethereum address so the user can scan it to fund the wallet.
+ */
+async function printAddressQrCode(address: string): Promise<void> {
+  const qr = await generateQrCode(address);
+  console.log('');
+  console.log(chalk.bold('  Scan to fund this wallet:'));
+  console.log(
+    qr
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n')
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Command: init
@@ -45,6 +72,7 @@ async function initWallet(options: { outputMode: OutputMode }): Promise<void> {
     console.log(formatSuccess('Wallet created'));
     console.log(formatInfo(`Address: ${chalk.cyan(account.address)}`));
     console.log(formatInfo('Fund this address with USDC on Base to use x402 payments.'));
+    await printAddressQrCode(account.address);
   }
 }
 
@@ -86,6 +114,8 @@ async function importWallet(options: {
   } else {
     console.log(formatSuccess('Wallet imported'));
     console.log(formatInfo(`Address: ${chalk.cyan(account.address)}`));
+    console.log(formatInfo('Fund this address with USDC on Base to use x402 payments.'));
+    await printAddressQrCode(account.address);
   }
 }
 
@@ -110,6 +140,7 @@ async function walletInfo(options: { outputMode: OutputMode }): Promise<void> {
 
   console.log(`  ${chalk.bold('Address')}   ${chalk.cyan(wallet.address)}`);
   console.log(`  ${chalk.bold('Created')}   ${wallet.createdAt}`);
+  await printAddressQrCode(wallet.address);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds QR code generation and display functionality to the x402 CLI commands, allowing users to easily scan and fund their wallets directly from the terminal.

## Key Changes
- Added `qrcode-terminal` dependency to generate QR codes in the terminal
- Implemented `generateQrCode()` helper function that wraps the qrcode-terminal library with Promise-based API
- Implemented `printAddressQrCode()` function to display formatted QR codes with proper indentation and labels
- Integrated QR code display into three x402 commands:
  - `x402 init`: Shows QR code after wallet creation
  - `x402 import`: Shows QR code after wallet import
  - `x402 info`: Shows QR code when displaying wallet information
- Updated CHANGELOG.md to document the new feature

## Implementation Details
- QR codes are generated using the "small" (half-block) mode for compact terminal display
- Each QR code is prefixed with "Scan to fund this wallet:" label
- Output is properly indented (2 spaces) to align with surrounding CLI output
- The implementation uses async/await pattern for consistency with the rest of the codebase

https://claude.ai/code/session_018sHtRmQ1eguqqLZxzDzxK9