### PR TITLE
fix: avoid auto-detecting OAuth profile when --x402 is used without --profile

### DIFF
--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -178,6 +178,7 @@ export async function connectSession(
   // Skip OAuth profile resolution when:
   // - --no-profile is specified (explicit anonymous connection)
   // - --header "Authorization: ..." is provided (explicit bearer token)
+  // - --x402 is specified (x402 payment auth instead of OAuth)
   let profileName: string | undefined;
   if (serverConfig.url) {
     if (options.noProfile) {
@@ -186,6 +187,10 @@ export async function connectSession(
       logger.debug(
         'Skipping OAuth profile auto-detection: explicit Authorization header provided via --header'
       );
+    } else if (options.x402 && !options.profile) {
+      // When using --x402 without explicit --profile, don't try to auto-discover default profile
+      // since x402 itself serves as the authentication mechanism
+      logger.debug('Skipping OAuth profile auto-detection: --x402 specified');
     } else {
       profileName = await resolveAuthProfile(serverConfig.url, target, options.profile, {
         sessionName: name,
@@ -653,7 +658,7 @@ export async function restartSession(
     // `mcpc login <server>` to create a default profile, and restarts the session.
     const hasExplicitAuthHeader = headers?.Authorization !== undefined;
     let profileName = session.profileName;
-    if (!profileName && serverConfig.url && !hasExplicitAuthHeader) {
+    if (!profileName && serverConfig.url && !hasExplicitAuthHeader && !session.x402) {
       profileName = await resolveAuthProfile(serverConfig.url, serverConfig.url, undefined, {
         sessionName: name,
       });


### PR DESCRIPTION
## Summary
- Prevents auto-detecting a default OAuth profile when the `--x402` flag is specified and no explicit `--profile` is passed.
- This fixes the issue where `mcpc connect "mcp.apify.com?payment=x402" @session --x402` would incorrectly try to use an existing OAuth profile instead of relying on x402 payment auth.
- The logic has been updated in both the `connectSession` and `restartSession` flows.