### PR TITLE
Improve chalk mock and enhance tool params formatting

### DIFF
--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -446,7 +446,8 @@ export function formatToolParamsInline(schema: Record<string, unknown>): string 
 
   const paramStrings: string[] = shown.map(({ name, required }) => {
     const typeStr = shortType(properties[name] ?? {});
-    return required ? `${name}:${typeStr}` : `${name}?:${typeStr}`;
+    const dimType = chalk.dim.white(`:${typeStr}`);
+    return required ? `${name}${dimType}` : `${name}${chalk.dim.white('?')}${dimType}`;
   });
 
   if (hidden > 0) {

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -5,31 +5,36 @@
 import { extractSingleTextContent } from '../../../src/cli/tool-result.js';
 
 // Mock chalk to return plain strings (required because Jest can't handle chalk's ESM imports)
+// Create a chainable identity function: each call returns the string, each property returns another chainable fn
+function chainable(
+  fn: (s: string) => string = (s: string) => s
+): ((s: string) => string) & Record<string, (s: string) => string> {
+  const proxy = new Proxy(fn, {
+    get(_target, _prop) {
+      return chainable(fn);
+    },
+  });
+  return proxy as ((s: string) => string) & Record<string, (s: string) => string>;
+}
+const mockChalk: Record<string, unknown> = {};
+for (const name of [
+  'cyan',
+  'yellow',
+  'red',
+  'dim',
+  'gray',
+  'bold',
+  'green',
+  'greenBright',
+  'blue',
+  'magenta',
+  'white',
+]) {
+  mockChalk[name] = chainable();
+}
 jest.mock('chalk', () => ({
-  default: {
-    cyan: (s: string) => s,
-    yellow: (s: string) => s,
-    red: (s: string) => s,
-    dim: (s: string) => s,
-    gray: (s: string) => s,
-    bold: (s: string) => s,
-    green: (s: string) => s,
-    greenBright: (s: string) => s,
-    blue: (s: string) => s,
-    magenta: (s: string) => s,
-    white: (s: string) => s,
-  },
-  cyan: (s: string) => s,
-  yellow: (s: string) => s,
-  red: (s: string) => s,
-  dim: (s: string) => s,
-  gray: (s: string) => s,
-  bold: (s: string) => s,
-  green: (s: string) => s,
-  greenBright: (s: string) => s,
-  blue: (s: string) => s,
-  magenta: (s: string) => s,
-  white: (s: string) => s,
+  default: { ...mockChalk },
+  ...mockChalk,
 }));
 
 // Mock sessions module before importing output


### PR DESCRIPTION
## Summary
This PR improves the chalk mock implementation in tests and enhances the visual formatting of tool parameters in the CLI output.

## Key Changes

- **Enhanced chalk mock**: Replaced the static mock with a chainable proxy-based implementation that properly handles method chaining (e.g., `chalk.dim.white()`). This fixes issues where chalk methods are chained together, which the previous flat mock couldn't support.

- **Improved tool params formatting**: Updated `formatToolParamsInline()` to apply visual styling to type annotations and optional markers:
  - Type annotations (`:typeStr`) are now dimmed using `chalk.dim.white()`
  - Optional markers (`?`) are also dimmed for consistency
  - This provides better visual hierarchy by de-emphasizing type information

## Implementation Details

The new `chainable()` function creates a Proxy that:
- Returns the original function when called as a function
- Returns another chainable function for any property access
- Allows arbitrary chaining like `chalk.dim.white()` while maintaining the identity function behavior (returns input string unchanged)

This approach is more maintainable and flexible than the previous hardcoded mock, as it automatically supports any chalk method combination without explicit enumeration.

https://claude.ai/code/session_01LarYwyTd8QF8YnZSwPqdoy