### PR TITLE
Fix false positive auth errors from MCP JSON-RPC and numeric substrings

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -21,7 +21,13 @@ import {
   cleanupOrphanedLogFiles,
   isSessionExpiredError,
 } from '../lib/index.js';
-import { ClientError, NetworkError, AuthError, isAuthenticationError } from '../lib/index.js';
+import {
+  ClientError,
+  ServerError,
+  NetworkError,
+  AuthError,
+  isAuthenticationError,
+} from '../lib/index.js';
 import { getSession, loadSessions, updateSession } from '../lib/sessions.js';
 import type { AuthCredentials, X402WalletCredentials } from '../lib/types.js';
 import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
@@ -821,11 +827,26 @@ class BridgeProcess {
    * Session expiry is checked first since it's more specific (404/session-not-found),
    * while auth errors are broader (401/403/unauthorized) and could overlap.
    *
+   * Skips application-level MCP errors (JSON-RPC errors from server handlers like
+   * "tool not found") since these should never cause session status changes. Only
+   * transport-level errors (HTTP 401/403/404) should trigger auth/expiry detection.
+   *
    * For auth errors, if a token manager is available, we attempt to refresh the token
    * before giving up. This handles transient auth failures (e.g., expired access token
    * that can be refreshed) without unnecessarily killing the session.
    */
   private async handlePossibleExpiration(error: Error): Promise<void> {
+    // ServerError wraps errors from mcp-client.ts methods. Check the original error
+    // to distinguish application-level JSON-RPC errors (tool not found, etc.) from
+    // transport-level errors (HTTP 401/403/404). The SDK's McpError class (name: 'McpError')
+    // indicates a JSON-RPC error response — these are application-level and should be skipped.
+    if (error instanceof ServerError) {
+      const originalError = (error.details as { originalError?: Error } | undefined)?.originalError;
+      if (originalError && originalError.name === 'McpError') {
+        return;
+      }
+    }
+
     let status: 'expired' | 'unauthorized' | null = null;
     if (isSessionExpiredError(error.message, { hadActiveSession: true })) {
       logger.warn('Session appears to be expired, marking as expired and shutting down');

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -83,10 +83,12 @@ export class AuthError extends McpError {
 }
 
 /**
- * Check if an error message indicates an authentication error from the server
+ * Check if an error message indicates an authentication error from the server.
+ * Uses word boundaries for numeric codes (401, 403) to avoid false positives
+ * from error codes or other numbers that happen to contain these digits.
  */
 export function isAuthenticationError(errorMessage: string): boolean {
-  return /invalid_token|unauthorized|missing.*token|access.*token|authentication|re-authenticate|401|403/i.test(
+  return /invalid_token|unauthorized|missing.*token|access.*token|authentication|re-authenticate|\b401\b|\b403\b/i.test(
     errorMessage
   );
 }

--- a/test/unit/bridge/session-expiration.test.ts
+++ b/test/unit/bridge/session-expiration.test.ts
@@ -257,5 +257,13 @@ describe('isAuthenticationError', () => {
       expect(isAuthenticationError('')).toBe(false);
       expect(isAuthenticationError('   ')).toBe(false);
     });
+
+    it('ignores error codes that contain 401/403 as substrings', () => {
+      // MCP JSON-RPC error codes like -32603 should not match
+      expect(isAuthenticationError('MCP error -32603: Unknown tool')).toBe(false);
+      // Port numbers or IDs containing 401/403 should not match
+      expect(isAuthenticationError('connection to port 14013 failed')).toBe(false);
+      expect(isAuthenticationError('request id 84017 timed out')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes false positive authentication error detection that was incorrectly triggering session expiration for application-level MCP errors and error messages containing numeric substrings like port numbers or request IDs.

## Key Changes
- **Import ServerError**: Added `ServerError` to imports in bridge/index.ts to enable proper error type checking
- **Skip application-level MCP errors**: Modified `handlePossibleExpiration()` to detect and skip JSON-RPC errors (identified by `McpError` name) that originate from MCP server handlers, preventing false session expiration triggers
- **Fix numeric substring matching**: Updated `isAuthenticationError()` regex to use word boundaries (`\b401\b`, `\b403\b`) instead of bare numeric patterns, preventing false matches from port numbers, error codes, and request IDs
- **Add test coverage**: Added test cases validating that MCP error codes (like -32603) and numeric substrings (port 14013, request id 84017) don't trigger authentication error detection

## Implementation Details
The fix distinguishes between two error categories:
1. **Transport-level errors** (HTTP 401/403/404): Should trigger session status checks
2. **Application-level errors** (JSON-RPC errors from tool handlers): Should be ignored

The `ServerError` wrapper's `originalError` property is inspected to identify `McpError` instances, which represent JSON-RPC protocol errors rather than authentication failures. This prevents legitimate tool execution errors from incorrectly terminating sessions.

https://claude.ai/code/session_012EAWd9vRx94WnNQ5nPUPzx