### PR TITLE
Apply --max-chars consistently to all commands, skip in --json mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `connect` command now auto-generates session name when `@session` is omitted (e.g., `mcpc connect mcp.apify.com` creates `@apify`). If a session for the same server already exists with matching auth settings, it is reused instead of creating a duplicate.
-- `--max-chars <chars>` global option to truncate large tool/prompt/resource output
+- `--max-chars <n>` option for `tools-call`, `prompts-get`, and `resources-read` to truncate large output (human mode only)
 - `tools-call <tool> --help` shows tool parameter schema (shortcut for `tools-get`)
 - "Did you mean?" suggestions for unknown commands, including reversed names (e.g., `list-tools` → `tools-list`)
 - `--json` output documentation in `--help` for all commands, describing the MCP object shape returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `connect` command now auto-generates session name when `@session` is omitted (e.g., `mcpc connect mcp.apify.com` creates `@apify`). If a session for the same server already exists with matching auth settings, it is reused instead of creating a duplicate.
-- `--max-chars <n>` option for `tools-call`, `prompts-get`, and `resources-read` to truncate large output (human mode only)
+- `--max-chars <n>` global option to truncate output to a given number of characters (ignored in `--json` mode)
 - `tools-call <tool> --help` shows tool parameter schema (shortcut for `tools-get`)
 - "Did you mean?" suggestions for unknown commands, including reversed names (e.g., `list-tools` → `tools-list`)
 - `--json` output documentation in `--help` for all commands, describing the MCP object shape returned

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Options:
   --schema <file>              Validate tool/prompt schema against expected schema
   --schema-mode <mode>         Schema validation mode: strict, compatible (default), ignore
   --timeout <seconds>          Request timeout in seconds (default: 300)
-  --max-chars <n>              Truncate tool/prompt output to this many characters
   --insecure                   Skip TLS certificate verification (for self-signed certs)
   -v, --version                Output the version number
   -h, --help                   Display help

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Options:
   --schema <file>              Validate tool/prompt schema against expected schema
   --schema-mode <mode>         Schema validation mode: strict, compatible (default), ignore
   --timeout <seconds>          Request timeout in seconds (default: 300)
+  --max-chars <n>              Truncate output to n characters (ignored in --json mode)
   --insecure                   Skip TLS certificate verification (for self-signed certs)
   -v, --version                Output the version number
   -h, --help                   Display help

--- a/src/cli/commands/prompts.ts
+++ b/src/cli/commands/prompts.ts
@@ -108,7 +108,7 @@ export async function getPrompt(
     const result = await client.getPrompt(name, promptArgs);
 
     let output = formatOutput(result, options.outputMode);
-    if (options.maxChars) {
+    if (options.maxChars && options.outputMode === 'human') {
       output = truncateOutput(output, options.maxChars);
     }
     console.log(output);

--- a/src/cli/commands/prompts.ts
+++ b/src/cli/commands/prompts.ts
@@ -3,7 +3,7 @@
  */
 
 import type { CommandOptions } from '../../lib/types.js';
-import { formatOutput, formatWarning, truncateOutput } from '../output.js';
+import { formatOutput, formatWarning } from '../output.js';
 import { withMcpClient } from '../helpers.js';
 import { parseCommandArgs, hasStdinData, readStdinArgs } from '../parser.js';
 import { ClientError } from '../../lib/errors.js';
@@ -31,7 +31,11 @@ export async function listPrompts(target: string, options: CommandOptions): Prom
       cursor = result.nextCursor;
     } while (cursor);
 
-    console.log(formatOutput(allPrompts, options.outputMode));
+    console.log(
+      formatOutput(allPrompts, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
   });
 }
 
@@ -107,10 +111,10 @@ export async function getPrompt(
 
     const result = await client.getPrompt(name, promptArgs);
 
-    let output = formatOutput(result, options.outputMode);
-    if (options.maxChars && options.outputMode === 'human') {
-      output = truncateOutput(output, options.maxChars);
-    }
-    console.log(output);
+    console.log(
+      formatOutput(result, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
   });
 }

--- a/src/cli/commands/resources.ts
+++ b/src/cli/commands/resources.ts
@@ -84,7 +84,7 @@ export async function getResource(
     }
 
     let output = formatOutput(result, options.outputMode);
-    if (options.maxChars) {
+    if (options.maxChars && options.outputMode === 'human') {
       output = truncateOutput(output, options.maxChars);
     }
     console.log(output);

--- a/src/cli/commands/resources.ts
+++ b/src/cli/commands/resources.ts
@@ -2,7 +2,7 @@
  * Resources command handlers
  */
 
-import { formatOutput, formatSuccess, truncateOutput } from '../output.js';
+import { formatOutput, formatSuccess } from '../output.js';
 import { withMcpClient } from '../helpers.js';
 import type { CommandOptions } from '../../lib/types.js';
 
@@ -22,7 +22,11 @@ export async function listResources(target: string, options: CommandOptions): Pr
       cursor = result.nextCursor;
     } while (cursor);
 
-    console.log(formatOutput(allResources, options.outputMode));
+    console.log(
+      formatOutput(allResources, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
   });
 }
 
@@ -45,7 +49,11 @@ export async function listResourceTemplates(
       cursor = result.nextCursor;
     } while (cursor);
 
-    console.log(formatOutput(allTemplates, options.outputMode));
+    console.log(
+      formatOutput(allTemplates, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
   });
 }
 
@@ -83,11 +91,11 @@ export async function getResource(
       return;
     }
 
-    let output = formatOutput(result, options.outputMode);
-    if (options.maxChars && options.outputMode === 'human') {
-      output = truncateOutput(output, options.maxChars);
-    }
-    console.log(output);
+    console.log(
+      formatOutput(result, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
   });
 }
 

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -12,7 +12,6 @@ import {
   formatError,
   formatWarning,
   formatInfo,
-  truncateOutput,
 } from '../output.js';
 import { ClientError } from '../../lib/errors.js';
 import type { CommandOptions, TaskUpdate } from '../../lib/types.js';
@@ -40,6 +39,7 @@ export async function listTools(
     console.log(
       formatOutput(result.tools, options.outputMode, {
         ...(options.full && { full: true }),
+        ...(options.maxChars && { maxChars: options.maxChars }),
         sessionName: target,
       })
     );
@@ -370,11 +370,11 @@ export async function callTool(
       }
     }
 
-    let output = formatOutput(result, options.outputMode);
-    if (options.maxChars && options.outputMode === 'human') {
-      output = truncateOutput(output, options.maxChars);
-    }
-    console.log(output);
+    console.log(
+      formatOutput(result, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
 
     // Show hint for getting tool schema when the tool returned an error
     if (result.isError && options.outputMode === 'human') {

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -371,7 +371,7 @@ export async function callTool(
     }
 
     let output = formatOutput(result, options.outputMode);
-    if (options.maxChars) {
+    if (options.maxChars && options.outputMode === 'human') {
       output = truncateOutput(output, options.maxChars);
     }
     console.log(output);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -400,6 +400,7 @@ function createTopLevelProgram(): Command {
     .option('--schema <file>', 'Validate tool/prompt schema against expected schema')
     .option('--schema-mode <mode>', 'Schema validation mode: strict, compatible (default), ignore')
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 300)')
+    .option('--max-chars <n>', 'Truncate output to n characters (ignored in --json mode)')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
     .version(mcpcVersion, '-v, --version', 'Output the version number')
     .helpOption('-h, --help', 'Display help');
@@ -914,7 +915,6 @@ ${jsonHelp('`{ tools?: Tool[], resources?: Resource[], prompts?: Prompt[], instr
     .helpOption(false) // Disable built-in --help so we can intercept it for tool schema
     .option('--task', 'Use async task execution (experimental)')
     .option('--detach', 'Start task and return immediately with task ID (implies --task)')
-    .option('--max-chars <n>', 'Truncate output to n characters (human mode only)')
     .addHelpText(
       'after',
       `
@@ -1029,7 +1029,6 @@ ${jsonHelp('`CallToolResult`', '`{ content: [{ type, text?, ... }], isError?, st
     .description('Read an MCP resource by URI.')
     .option('-o, --output <file>', 'Write resource to file')
     .option('--max-size <bytes>', 'Maximum resource size in bytes')
-    .option('--max-chars <n>', 'Truncate output to n characters (human mode only)')
     .addHelpText(
       'after',
       jsonHelp(
@@ -1111,7 +1110,6 @@ ${jsonHelp('`CallToolResult`', '`{ content: [{ type, text?, ... }], isError?, st
   program
     .command('prompts-get <name> [args...]')
     .description('Get an MCP prompt with arguments.')
-    .option('--max-chars <n>', 'Truncate output to n characters (human mode only)')
     .addHelpText(
       'after',
       jsonHelp(
@@ -1178,6 +1176,7 @@ function createSessionProgram(): Command {
     .option('--schema <file>', 'Validate tool/prompt schema against expected schema')
     .option('--schema-mode <mode>', 'Schema validation mode: strict, compatible (default), ignore')
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 300)')
+    .option('--max-chars <n>', 'Truncate output to n characters (ignored in --json mode)')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
     .addHelpText(
       'after',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -400,7 +400,6 @@ function createTopLevelProgram(): Command {
     .option('--schema <file>', 'Validate tool/prompt schema against expected schema')
     .option('--schema-mode <mode>', 'Schema validation mode: strict, compatible (default), ignore')
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 300)')
-    .option('--max-chars <n>', 'Truncate tool/prompt output to this many characters')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
     .version(mcpcVersion, '-v, --version', 'Output the version number')
     .helpOption('-h, --help', 'Display help');
@@ -915,6 +914,7 @@ ${jsonHelp('`{ tools?: Tool[], resources?: Resource[], prompts?: Prompt[], instr
     .helpOption(false) // Disable built-in --help so we can intercept it for tool schema
     .option('--task', 'Use async task execution (experimental)')
     .option('--detach', 'Start task and return immediately with task ID (implies --task)')
+    .option('--max-chars <n>', 'Truncate output to n characters (human mode only)')
     .addHelpText(
       'after',
       `
@@ -1029,6 +1029,7 @@ ${jsonHelp('`CallToolResult`', '`{ content: [{ type, text?, ... }], isError?, st
     .description('Read an MCP resource by URI.')
     .option('-o, --output <file>', 'Write resource to file')
     .option('--max-size <bytes>', 'Maximum resource size in bytes')
+    .option('--max-chars <n>', 'Truncate output to n characters (human mode only)')
     .addHelpText(
       'after',
       jsonHelp(
@@ -1110,6 +1111,7 @@ ${jsonHelp('`CallToolResult`', '`{ content: [{ type, text?, ... }], isError?, st
   program
     .command('prompts-get <name> [args...]')
     .description('Get an MCP prompt with arguments.')
+    .option('--max-chars <n>', 'Truncate output to n characters (human mode only)')
     .addHelpText(
       'after',
       jsonHelp(
@@ -1176,7 +1178,6 @@ function createSessionProgram(): Command {
     .option('--schema <file>', 'Validate tool/prompt schema against expected schema')
     .option('--schema-mode <mode>', 'Schema validation mode: strict, compatible (default), ignore')
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 300)')
-    .option('--max-chars <n>', 'Truncate tool/prompt output to this many characters')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
     .addHelpText(
       'after',

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -77,6 +77,8 @@ export interface FormatOptions {
   full?: boolean;
   /** Session name for contextual hints (e.g. @apify) */
   sessionName?: string;
+  /** Truncate human-mode output to this many characters */
+  maxChars?: number;
 }
 
 /**
@@ -91,10 +93,13 @@ export function formatOutput(
   if (mode === 'json') {
     return formatJson(data);
   }
-  const output = formatHuman(data, options);
+  let output = formatHuman(data, options);
   // Ensure trailing newline for visual separation in shell (unless ends with code block)
   if (!output.endsWith('````') && !output.endsWith('\n')) {
-    return output + '\n';
+    output += '\n';
+  }
+  if (options?.maxChars) {
+    output = truncateOutput(output, options.maxChars);
   }
   return output;
 }

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -30,13 +30,7 @@ export function getJsonFromEnv(): boolean {
 }
 
 // Global options that take a value (not boolean flags)
-const GLOBAL_OPTIONS_WITH_VALUES = [
-  '--timeout',
-  '--profile',
-  '--schema',
-  '--schema-mode',
-  '--max-chars',
-];
+const GLOBAL_OPTIONS_WITH_VALUES = ['--timeout', '--profile', '--schema', '--schema-mode'];
 
 // All options that take a value — used by optionTakesValue() to correctly skip
 // the next arg when scanning for command tokens. Includes subcommand-specific
@@ -55,6 +49,7 @@ const OPTIONS_WITH_VALUES = [
   '-o',
   '--output',
   '--max-size',
+  '--max-chars',
   '--amount',
   '--expiry',
 ];

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -30,7 +30,13 @@ export function getJsonFromEnv(): boolean {
 }
 
 // Global options that take a value (not boolean flags)
-const GLOBAL_OPTIONS_WITH_VALUES = ['--timeout', '--profile', '--schema', '--schema-mode'];
+const GLOBAL_OPTIONS_WITH_VALUES = [
+  '--timeout',
+  '--profile',
+  '--schema',
+  '--schema-mode',
+  '--max-chars',
+];
 
 // All options that take a value — used by optionTakesValue() to correctly skip
 // the next arg when scanning for command tokens. Includes subcommand-specific
@@ -49,7 +55,6 @@ const OPTIONS_WITH_VALUES = [
   '-o',
   '--output',
   '--max-size',
-  '--max-chars',
   '--amount',
   '--expiry',
 ];


### PR DESCRIPTION
## Summary
- `--max-chars` truncation now applies consistently to **all** commands (not just `tools-call`, `prompts-get`, `resources-read`)
- Truncation is **skipped in `--json` mode** to avoid producing invalid JSON
- Truncation logic moved into `formatOutput()` so every command gets it for free

## Changes
- Added `maxChars` to `FormatOptions` and applied truncation centrally in `formatOutput()` (human mode only)
- Passed `maxChars` through `FormatOptions` at all `formatOutput()` call sites that use `options.outputMode`
- Removed per-handler `truncateOutput()` calls and cleaned up unused imports
- Updated help text: `--max-chars <n>  Truncate output to n characters (ignored in --json mode)`
- Updated CHANGELOG and README

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run test:unit` passes (500/500)
- [x] CI green (Node 20/22/24, E2E Node/Bun)

https://claude.ai/code/session_01PiFuVVaizRowPPHUwMPKVa