### PR TITLE
Add comprehensive e2e tests for --max-chars output truncation

### DIFF
--- a/test/e2e/suites/basic/max-chars.test.sh
+++ b/test/e2e/suites/basic/max-chars.test.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Test: --max-chars option (output truncation)
+# Tests that --max-chars truncates human output and is ignored in JSON mode
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "basic/max-chars"
+
+# Start test server
+start_test_server
+
+# Generate unique session name for this test
+SESSION=$(session_name "maxch")
+
+# Create session for testing
+test_case "setup: create session"
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
+assert_success
+_SESSIONS_CREATED+=("$SESSION")
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncates tools-call output
+# =============================================================================
+
+test_case "tools-call output is truncated with --max-chars"
+run_mcpc "$SESSION" tools-call echo 'message:=The quick brown fox jumps over the lazy dog' --max-chars 20
+assert_success
+assert_contains "$STDOUT" "output truncated"
+assert_contains "$STDOUT" "--max-chars"
+test_pass
+
+test_case "tools-call shows first N chars when truncated"
+run_mcpc "$SESSION" tools-call echo 'message:=ABCDEFGHIJ' --max-chars 5
+assert_success
+# The truncated output should start with the beginning of the formatted output
+assert_contains "$STDOUT" "output truncated"
+assert_contains "$STDOUT" "showing first 5 chars"
+test_pass
+
+test_case "tools-call not truncated when output fits within --max-chars"
+run_mcpc "$SESSION" tools-call echo 'message:=Hi' --max-chars 10000
+assert_success
+assert_contains "$STDOUT" "Hi"
+assert_not_contains "$STDOUT" "output truncated"
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncates tools-list output
+# =============================================================================
+
+test_case "tools-list output is truncated with small --max-chars"
+run_mcpc "$SESSION" tools-list --max-chars 30
+assert_success
+assert_contains "$STDOUT" "output truncated"
+test_pass
+
+test_case "tools-list not truncated with large --max-chars"
+run_mcpc "$SESSION" tools-list --max-chars 100000
+assert_success
+assert_not_contains "$STDOUT" "output truncated"
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncates resources-list output
+# =============================================================================
+
+test_case "resources-list output is truncated with small --max-chars"
+run_mcpc "$SESSION" resources-list --max-chars 30
+assert_success
+assert_contains "$STDOUT" "output truncated"
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncates resources-read output
+# =============================================================================
+
+test_case "resources-read output is truncated with small --max-chars"
+run_mcpc "$SESSION" resources-read "test://static/hello" --max-chars 5
+assert_success
+assert_contains "$STDOUT" "output truncated"
+test_pass
+
+test_case "resources-read not truncated with large --max-chars"
+run_mcpc "$SESSION" resources-read "test://static/hello" --max-chars 100000
+assert_success
+assert_not_contains "$STDOUT" "output truncated"
+assert_contains "$STDOUT" "Hello, World!"
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncates prompts-list output
+# =============================================================================
+
+test_case "prompts-list output is truncated with small --max-chars"
+run_mcpc "$SESSION" prompts-list --max-chars 30
+assert_success
+assert_contains "$STDOUT" "output truncated"
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncates prompts-get output
+# =============================================================================
+
+test_case "prompts-get output is truncated with small --max-chars"
+run_mcpc "$SESSION" prompts-get greeting name:=Alice --max-chars 10
+assert_success
+assert_contains "$STDOUT" "output truncated"
+test_pass
+
+# =============================================================================
+# Test: --max-chars is ignored in --json mode
+# =============================================================================
+
+test_case "tools-call --json ignores --max-chars"
+run_mcpc --json "$SESSION" tools-call echo 'message:=Hello World' --max-chars 5
+assert_success
+assert_json_valid "$STDOUT"
+assert_not_contains "$STDOUT" "output truncated"
+test_pass
+
+test_case "tools-list --json ignores --max-chars"
+run_mcpc --json "$SESSION" tools-list --max-chars 5
+assert_success
+assert_json_valid "$STDOUT"
+assert_not_contains "$STDOUT" "output truncated"
+test_pass
+
+test_case "resources-list --json ignores --max-chars"
+run_mcpc --json "$SESSION" resources-list --max-chars 5
+assert_success
+assert_json_valid "$STDOUT"
+assert_not_contains "$STDOUT" "output truncated"
+test_pass
+
+test_case "prompts-list --json ignores --max-chars"
+run_mcpc --json "$SESSION" prompts-list --max-chars 5
+assert_success
+assert_json_valid "$STDOUT"
+assert_not_contains "$STDOUT" "output truncated"
+test_pass
+
+# =============================================================================
+# Test: --max-chars truncation notice shows total size
+# =============================================================================
+
+test_case "truncation notice shows KB for large output"
+run_mcpc "$SESSION" tools-list --full --max-chars 10
+assert_success
+assert_contains "$STDOUT" "output truncated"
+assert_contains "$STDOUT" "KB total"
+test_pass
+
+test_case "truncation notice shows chars for small output"
+run_mcpc "$SESSION" tools-call echo 'message:=Short' --max-chars 3
+assert_success
+assert_contains "$STDOUT" "output truncated"
+assert_contains "$STDOUT" "chars"
+test_pass
+
+# =============================================================================
+# Test: --max-chars validation (invalid values)
+# =============================================================================
+
+test_case "--max-chars rejects zero"
+run_mcpc "$SESSION" tools-list --max-chars 0
+assert_failure
+assert_contains "$STDERR" "Invalid --max-chars"
+test_pass
+
+test_case "--max-chars rejects negative values"
+run_mcpc "$SESSION" tools-list --max-chars -5
+assert_failure
+assert_contains "$STDERR" "Invalid --max-chars"
+test_pass
+
+test_case "--max-chars rejects non-numeric values"
+run_mcpc "$SESSION" tools-list --max-chars abc
+assert_failure
+assert_contains "$STDERR" "Invalid --max-chars"
+test_pass
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+test_case "cleanup: close session"
+run_mcpc "$SESSION" close
+assert_success
+_SESSIONS_CREATED=("${_SESSIONS_CREATED[@]/$SESSION}")
+test_pass
+
+test_done


### PR DESCRIPTION
## Summary
This PR adds a comprehensive end-to-end test suite for the `--max-chars` option, which controls output truncation in human-readable mode while being ignored in JSON mode.

## Key Changes
- **New test file**: `test/e2e/suites/basic/max-chars.test.sh` with 192 lines of test coverage
- **Test coverage includes**:
  - Output truncation behavior for `tools-call`, `tools-list`, `resources-list`, `resources-read`, `prompts-list`, and `prompts-get` commands
  - Verification that truncation messages display correctly with character counts and size indicators (chars/KB)
  - Confirmation that `--max-chars` is properly ignored when using `--json` mode
  - Input validation tests for invalid values (zero, negative, non-numeric)
  - Edge cases like small vs. large output and small vs. large `--max-chars` values

## Notable Implementation Details
- Tests verify both truncation behavior (output is cut off) and user feedback (truncation notice is displayed)
- Tests confirm that JSON output is never truncated regardless of `--max-chars` setting
- Comprehensive validation testing ensures the option rejects invalid inputs with appropriate error messages
- Tests use the existing test framework (`framework.sh`) and follow established patterns for session management and assertions

https://claude.ai/code/session_01ExKTHAP8ADz2QfXi1vYh5p