### PR TITLE
Exclude shell command from --json output support

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -746,11 +746,14 @@ ${jsonHelp('`[{ sessionName, tools?: Tool[], resources?: Resource[], prompts?: P
   return program;
 }
 
+/** Commands that don't support --json output. */
+const NO_JSON_COMMANDS = new Set(['shell']);
+
 /**
  * Tune a command's help display: add --json option and hide --help.
  */
 function tuneCommandHelp(cmd: Command): void {
-  if (!cmd.options.some((o) => o.long === '--json')) {
+  if (!NO_JSON_COMMANDS.has(cmd.name()) && !cmd.options.some((o) => o.long === '--json')) {
     cmd.option('--json', 'Output in JSON format');
   }
   cmd.helpOption('-h, --help', 'Display help');


### PR DESCRIPTION
## Summary
Updated the CLI command help tuning logic to exclude the `shell` command from automatically receiving `--json` output support, as this command does not support JSON formatting.

## Changes
- Added a `NO_JSON_COMMANDS` Set to explicitly list commands that should not have the `--json` option added
- Modified `tuneCommandHelp()` to check if a command is in the exclusion list before adding the `--json` option
- The `shell` command is now the first command in this exclusion set

## Implementation Details
The change uses a simple Set-based allowlist approach to prevent the `--json` option from being added to commands that don't support it. This is more maintainable than checking command names inline and makes it easy to add additional commands to the exclusion list in the future if needed.

https://claude.ai/code/session_01LzhUFY1iNFbu7jkp18SEyS