### PR TITLE
Show bridge log file path in session info output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Did you mean?" suggestions for unknown commands, including reversed names (e.g., `list-tools` → `tools-list`)
 - `--json` output documentation in `--help` for all commands, describing the MCP object shape returned
 - `tools-get` now shows an example `tools-call` command with placeholder arguments based on the tool's schema
+- Session info output (`mcpc @session`) now shows the path to the bridge log file under a "Debugging" section, helping AI agents and users locate logs when troubleshooting
 
 ### Changed
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -22,7 +22,8 @@ import type {
   Task,
 } from '../lib/types.js';
 import { extractSingleTextContent } from './tool-result.js';
-import { isValidSessionName } from '../lib/utils.js';
+import { join } from 'node:path';
+import { isValidSessionName, getLogsDir } from '../lib/utils.js';
 import { getSession } from '../lib/sessions.js';
 
 // Re-export for external use
@@ -1320,6 +1321,15 @@ export function formatServerDetails(
 
   lines.push(commands.join('\n'));
   lines.push('');
+
+  // Debugging hint: bridge log file path (only shown for sessions, i.e. @name targets)
+  if (target.startsWith('@')) {
+    const sessionName = target.slice(1);
+    const logPath = join(getLogsDir(), `bridge-${sessionName}.log`);
+    lines.push(chalk.bold('Debugging:'));
+    lines.push(`${bullet} bridge log: ${bt}${logPath}${bt}`);
+    lines.push('');
+  }
 
   return lines.join('\n');
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1326,8 +1326,7 @@ export function formatServerDetails(
   if (target.startsWith('@')) {
     const sessionName = target.slice(1);
     const logPath = join(getLogsDir(), `bridge-${sessionName}.log`);
-    lines.push(chalk.bold('Debugging:'));
-    lines.push(`${bullet} bridge log: ${bt}${logPath}${bt}`);
+    lines.push(chalk.dim(`Session log for debugging: ${logPath}`));
     lines.push('');
   }
 


### PR DESCRIPTION
## Summary
Added a debugging hint to the session info output that displays the path to the bridge log file when viewing details for a specific session target.

## Changes
- Modified `formatServerDetails()` in `src/cli/output.ts` to include the bridge log file path for session targets
- Added imports for `join` from `node:path` and `getLogsDir` from utils
- When the target starts with `@` (indicating a session), the function now constructs and displays the log file path in a dimmed format at the end of the output
- Updated CHANGELOG.md to document this new feature

## Implementation Details
- The log file path is constructed using `join(getLogsDir(), `bridge-${sessionName}.log`)` where the session name is extracted from the target by removing the leading `@`
- The path is displayed in a dimmed color using `chalk.dim()` to indicate it's supplementary information
- This only appears for session-specific targets (those starting with `@`), not for general server info
- The hint is positioned at the end of the output after command examples, making it easy to spot when troubleshooting

https://claude.ai/code/session_01KT1NuuGwBFExXUzQC9CEVW