### PR TITLE
Route OAuth flow interactive prompts to stderr for clean stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `connect` now verifies the server responds before reporting success; shows a warning with the actual error when the server is unreachable
 - HTTP 404 during initial connect no longer misclassified as "session expired"; error messages now include the actual HTTP error and server URL
 - `build:readme` script failing on macOS due to `sed -i` platform difference
+- `mcpc login --json` now writes interactive prompts (authorization URL, "Press Enter to open browser", browser-open status, callback-URL paste prompt) to stderr, so stdout contains only the final JSON result and is safe to pipe to `jq` or redirect to a file
 
 ## [0.2.4] - 2026-04-07
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -596,7 +596,10 @@ ${chalk.bold('OAuth client registration approaches (per MCP authorization spec):
 
   See https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
 
-${jsonHelp('`{ profile, serverUrl, scopes }`')}`
+${jsonHelp('`{ profile, serverUrl, scopes }`')}
+  Interactive prompts and the authorization URL are written to stderr, so
+  stdout contains only the final JSON result and is safe to pipe or redirect.
+`
     )
     .action(async (server, opts, command) => {
       if (!server) {

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -115,10 +115,10 @@ async function waitForEnterKey(prompt: string): Promise<boolean> {
     return true;
   }
 
-  process.stdout.write(prompt);
+  process.stderr.write(prompt);
 
   const { promise } = setupKeyListener<boolean>((char) => {
-    console.log(''); // Print newline after keypress
+    console.error(''); // Print newline after keypress
     if (char === ENTER_CR || char === ENTER_LF) {
       return { done: true, value: true };
     }
@@ -359,7 +359,7 @@ function promptForCallbackUrl(): {
 } {
   const rl = createInterface({
     input: process.stdin,
-    output: process.stdout,
+    output: process.stderr,
   });
 
   let cleaned = false;
@@ -528,7 +528,8 @@ export async function performOAuthFlow(
     // Override redirectToAuthorization to open browser
     provider.redirectToAuthorization = async (authorizationUrl: URL) => {
       logger.debug('Opening browser for authorization...');
-      console.log(`\nAuthorization URL: ${authorizationUrl.toString()}`);
+      // Interactive chatter goes to stderr so stdout stays clean for --json output.
+      console.error(`\nAuthorization URL: ${authorizationUrl.toString()}`);
 
       // Ask for confirmation before opening browser
       const confirmed = await waitForEnterKey(
@@ -538,20 +539,20 @@ export async function performOAuthFlow(
         throw new ClientError('Authentication cancelled by user');
       }
 
-      console.log('Opening browser...');
+      console.error('Opening browser...');
       const opened = await tryOpenBrowser(authorizationUrl.toString());
 
       if (opened) {
-        console.log('If the browser does not open automatically, please visit the URL above.');
-        console.log('Press Esc to cancel.\n');
+        console.error('If the browser does not open automatically, please visit the URL above.');
+        console.error('Press Esc to cancel.\n');
         // Set up escape key handler AFTER Enter confirmation (to avoid raw mode conflicts)
         escapeHandlerRef.current = waitForEscapeKey();
       } else {
         browserFailed = true;
-        console.log(
+        console.error(
           '\nCould not open browser. Please open the authorization URL above in your browser.'
         );
-        console.log(
+        console.error(
           'After authorizing, copy the full callback URL from the browser address bar and paste it here.'
         );
       }


### PR DESCRIPTION
## Summary
This change redirects all interactive prompts and status messages during the OAuth login flow to stderr, ensuring that stdout remains clean and contains only the final JSON result. This makes the output safe to pipe to tools like `jq` or redirect to files.

## Key Changes
- **OAuth flow output redirection**: Changed all interactive prompts in `src/lib/auth/oauth-flow.ts` to use stderr instead of stdout:
  - `process.stdout.write()` → `process.stderr.write()` for the Enter key prompt
  - `console.log()` → `console.error()` for all status messages (authorization URL, browser opening status, callback URL paste instructions)
  - Updated `createInterface()` output stream from `process.stdout` to `process.stderr` for the callback URL prompt

- **Help text update**: Added clarification in `src/cli/index.ts` to the `login` command help text documenting that interactive prompts are written to stderr while stdout contains only the final JSON result

- **Changelog entry**: Documented this fix in CHANGELOG.md to inform users that `mcpc login --json` now properly separates interactive output from JSON output

## Implementation Details
The changes maintain all existing functionality while improving the user experience for programmatic usage. Interactive chatter (prompts, status messages, URLs) now goes to stderr, allowing stdout to be reliably used for structured output (JSON) in automation scripts and pipelines.

https://claude.ai/code/session_0121enps74eMNA3BbhNYMjPX