### PR TITLE
Fix stale process cache after spawning bridge process

### DIFF
--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -20,6 +20,7 @@ import {
   getSocketPath,
   waitForFile,
   isProcessAlive,
+  invalidateProcessAliveCache,
   getLogsDir,
   isSessionExpiredError,
   enrichErrorMessage,
@@ -190,6 +191,13 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     detached: true,
     stdio: 'ignore', // Don't inherit stdio (run in background)
   });
+
+  // Reset the Windows tasklist cache so the freshly spawned PID is observable
+  // by subsequent isProcessAlive() checks within this CLI invocation (e.g. the
+  // ensureBridgeReady health check run right after this in restart/connect).
+  // Without this, a stale pre-spawn snapshot returns false for the new PID,
+  // triggering a spurious double-restart that breaks explicit restart semantics.
+  invalidateProcessAliveCache();
 
   // Allow the bridge to run independently
   bridgeProcess.unref();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -416,6 +416,17 @@ let _tasklistCache: Set<number> | null = null;
 let _tasklistCacheTime = 0;
 const TASKLIST_CACHE_TTL = 2000; // 2 seconds
 
+/**
+ * Invalidate the Windows tasklist cache used by isProcessAlive().
+ * Call this after spawning a new child process so subsequent
+ * isProcessAlive() checks pick up the new PID instead of returning
+ * a stale false-negative from the pre-spawn snapshot.
+ */
+export function invalidateProcessAliveCache(): void {
+  _tasklistCache = null;
+  _tasklistCacheTime = 0;
+}
+
 function isProcessAliveTasklist(pid: number): boolean {
   const now = Date.now();
   if (_tasklistCache && now - _tasklistCacheTime < TASKLIST_CACHE_TTL) {


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Windows tasklist cache used by `isProcessAlive()` could return stale results after spawning a new bridge process, causing spurious double-restart failures.

## Changes
- **Added `invalidateProcessAliveCache()` export** in `src/lib/utils.ts`: New public function to clear the Windows tasklist cache and reset its TTL timer
- **Call cache invalidation after spawn** in `src/lib/bridge-manager.ts`: Immediately after spawning the bridge process, invalidate the cache so subsequent `isProcessAlive()` checks can observe the newly spawned PID instead of relying on a pre-spawn snapshot

## Implementation Details
The Windows process alive check uses a 2-second TTL cache to avoid excessive `tasklist` command invocations. However, when a new bridge process is spawned, the cache may still contain a snapshot from before the spawn, causing `isProcessAlive()` to incorrectly return `false` for the new PID. This triggered spurious double-restart behavior in health checks that run immediately after spawning.

By invalidating the cache right after spawning, we ensure the next `isProcessAlive()` call will fetch a fresh tasklist that includes the newly spawned process.

https://claude.ai/code/session_014w5QYdwZKHA5REd2pTEXwP