### PR TITLE
feat: add --callback-port flag to login command

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -21,6 +21,7 @@ export async function login(
     clientId?: string;
     clientSecret?: string;
     clientMetadataUrl?: string;
+    callbackPort?: number;
   }
 ): Promise<void> {
   try {
@@ -64,7 +65,8 @@ export async function login(
       normalizedUrl,
       profileName,
       options.scope,
-      clientCredentials
+      clientCredentials,
+      options.callbackPort
     );
 
     if (options.outputMode === 'human') {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -599,6 +599,11 @@ ${chalk.bold('OAuth client registration approaches:')}
 ${jsonHelp('Interactive prompts are written to stderr, stdout contains a clean JSON object', '`{ profile, serverUrl, scopes }`')}
 `
     )
+    .option(
+      '--callback-port <port>',
+      'OAuth callback port (default: auto-select from 8000)',
+      parseInt
+    )
     .action(async (server, opts, command) => {
       if (!server) {
         throw new ClientError(
@@ -611,6 +616,7 @@ ${jsonHelp('Interactive prompts are written to stderr, stdout contains a clean J
         clientId: opts.clientId,
         clientSecret: opts.clientSecret,
         clientMetadataUrl: opts.clientMetadataUrl,
+        callbackPort: opts.callbackPort,
         ...getOptionsFromCommand(command),
       });
     });

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -437,7 +437,8 @@ export async function performOAuthFlow(
   serverUrl: string,
   profileName: string,
   scope?: string,
-  clientCredentials?: { clientId?: string; clientSecret?: string; clientMetadataUrl?: string }
+  clientCredentials?: { clientId?: string; clientSecret?: string; clientMetadataUrl?: string },
+  callbackPort?: number
 ): Promise<OAuthFlowResult> {
   logger.debug(`Starting OAuth flow for ${serverUrl} (profile: ${profileName})`);
 
@@ -455,7 +456,7 @@ export async function performOAuthFlow(
   }
 
   // Find available port for callback server
-  const port = await findAvailablePort(8000);
+  const port = callbackPort || await findAvailablePort(8000);
   const redirectUrl = `http://localhost:${port}/callback`;
 
   logger.debug(`Using redirect URL: ${redirectUrl}`);


### PR DESCRIPTION
## Summary
- Add `--callback-port <port>` option to `mcpc login` to specify the OAuth callback port
- Some OAuth providers (e.g., Slack MCP) register specific redirect URIs with fixed ports — the hardcoded port 8000 causes `redirect_uri` mismatch errors
- When `--callback-port` is provided, it's used directly instead of auto-selecting from port 8000

## Motivation

Slack's MCP server (`mcp.slack.com/mcp`) uses client ID `1601185624273.8899143856786` with a registered redirect URI on port 3118. Without this flag, `mcpc login` always starts the callback server on port 8000, which Slack rejects:

```
redirect_uri did not match any configured URIs. Passed URI: http://localhost:8000/callback
```

With this fix:
```bash
mcpc login mcp.slack.com/mcp --client-id "1601185624273.8899143856786" --callback-port 3118
```

## Test plan
- [ ] `mcpc login --help` shows the new `--callback-port` option
- [ ] `mcpc login <server> --client-id <id> --callback-port 3118` uses port 3118 for the callback
- [ ] Without `--callback-port`, behavior is unchanged (auto-selects from 8000)
- [ ] Tested successfully against Slack MCP OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)