### PR TITLE
Add tasks-result command to fetch final async task results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `tasks-result <taskId>` command that fetches the final `CallToolResult` payload of an async task via the MCP `tasks/result` method. Blocks until the task reaches a terminal state, then prints the payload using the same renderer as `tools-call` (`--json` returns the raw result).
+
 ## [0.2.5] - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,6 +106,53 @@ mcpc @fs tools-list
 <!-- AUTO-GENERATED: mcpc --help -->
 
 ```
+Usage: mcpc [<@session>] [<command>] [options]
+
+Universal command-line client for the Model Context Protocol (MCP).
+
+Commands:
+  connect <server> [@session]  Connect to an MCP server and start a named @session
+  close <@session>             Close a session
+  restart <@session>           Restart a session (losing all state)
+  shell <@session>             Open interactive shell for a session
+  login <server>               Interactively login to a server using OAuth and save profile
+  logout <server>              Delete an OAuth profile for a server
+  clean [resources...]         Clean up mcpc data (sessions, profiles, logs, all)
+  grep <pattern>               Search tools and instructions across all active sessions
+  x402 [subcommand] [args...]  Configure an x402 payment wallet (EXPERIMENTAL)
+  help [command] [subcommand]  Show help for a specific command
+
+Options:
+  --json                       Output in JSON format for scripting
+  --verbose                    Enable debug logging
+  --profile <name>             OAuth profile for the server ("default" if not provided)
+  --timeout <seconds>          Request timeout in seconds (default: 300)
+  --max-chars <n>              Truncate output to n characters (ignored in --json mode)
+  --insecure                   Skip TLS certificate verification (for self-signed certs)
+  -v, --version                Output the version number
+  -h, --help                   Display help
+
+MCP session commands (after connecting):
+  <@session>                   Show MCP server info, capabilities, and tools overview
+  <@session> grep <pattern>    Search tools and instructions
+  <@session> tools-list        List all server tools
+  <@session> tools-get <name>  Get tool details and schema
+  <@session> tools-call <name> [arg:=val ... | <json> | <stdin]
+  <@session> prompts-list
+  <@session> prompts-get <name> [arg:=val ... | <json> | <stdin]
+  <@session> resources-list
+  <@session> resources-read <uri>
+  <@session> resources-subscribe <uri>
+  <@session> resources-unsubscribe <uri>
+  <@session> resources-templates-list
+  <@session> tasks-list
+  <@session> tasks-get <taskId>
+  <@session> tasks-result <taskId>
+  <@session> tasks-cancel <taskId>
+  <@session> logging-set-level <level>
+  <@session> ping
+
+Run "mcpc" without arguments to show active sessions and OAuth profiles.
 ```
 
 ### General actions
@@ -1016,6 +1063,9 @@ mcpc @apify tasks-list
 # Check task status
 mcpc @apify tasks-get <taskId>
 
+# Get the task result (blocks until the task reaches a terminal state)
+mcpc @apify tasks-result <taskId>
+
 # Cancel a running task
 mcpc @apify tasks-cancel <taskId>
 ```
@@ -1023,6 +1073,8 @@ mcpc @apify tasks-cancel <taskId>
 With `--task`, the CLI shows a progress spinner with elapsed time, server status messages,
 and progress notifications. Press **ESC** during execution to detach and get the task ID
 for later retrieval. With `--detach`, the task starts and returns the task ID immediately.
+Use `tasks-result <taskId>` to fetch the final `CallToolResult` payload once the task
+completes.
 
 `tools-list` and `tools-get` show task support annotations per tool:
 `[task:optional]`, `[task:required]`, or `[task:forbidden]`.

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1294,6 +1294,12 @@ class BridgeProcess {
           break;
         }
 
+        case 'getTaskResult': {
+          const params = message.params as { taskId: string };
+          result = await this.client.getTaskResult(params.taskId);
+          break;
+        }
+
         case 'cancelTask': {
           const params = message.params as { taskId: string };
           result = await this.client.cancelTask(params.taskId);

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -7,6 +7,7 @@ import { formatOutput, formatSuccess, formatError } from '../output.js';
 import type { CommandOptions } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 import { formatTask, formatTasks } from '../output.js';
+import { renderCallToolResult } from './tools.js';
 
 /**
  * Get the final result of a task (wraps MCP `tasks/result`).
@@ -20,20 +21,10 @@ export async function getTaskResult(
 ): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
     const result = await client.getTaskResult(taskId);
-
-    if (options.outputMode === 'human') {
-      if (result.isError) {
-        console.log(formatError(`Task ${taskId} returned an error`));
-      } else {
-        console.log(formatSuccess(`Task ${taskId} result`));
-      }
-    }
-
-    console.log(
-      formatOutput(result, options.outputMode, {
-        ...(options.maxChars && { maxChars: options.maxChars }),
-      })
-    );
+    renderCallToolResult(result, options, {
+      success: `Task ${taskId} completed`,
+      error: `Task ${taskId} returned an error`,
+    });
   });
 }
 

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -3,7 +3,6 @@
  * Manage async tasks on MCP servers that support the tasks capability
  */
 
-import chalk from 'chalk';
 import { formatOutput, formatSuccess, formatError } from '../output.js';
 import type { CommandOptions } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -50,9 +50,7 @@ export async function listTasks(target: string, options: CommandOptions): Promis
       } else {
         console.log(formatTasks(allTasks));
         console.log(
-          chalk.dim(
-            `To fetch the task's final result, run:\n  mcpc ${target} tasks-result <taskId>`
-          )
+          `\nTo fetch the task's final result, run:\n  mcpc ${target} tasks-result <taskId>`
         );
       }
     } else {

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -3,7 +3,8 @@
  * Manage async tasks on MCP servers that support the tasks capability
  */
 
-import { formatOutput, formatSuccess, formatError } from '../output.js';
+import chalk from 'chalk';
+import { formatOutput, formatSuccess, formatError, formatInfo } from '../output.js';
 import type { CommandOptions } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 import { formatTask, formatTasks } from '../output.js';
@@ -48,6 +49,11 @@ export async function listTasks(target: string, options: CommandOptions): Promis
         console.log(formatSuccess('No active tasks'));
       } else {
         console.log(formatTasks(allTasks));
+        console.log(
+          formatInfo(
+            `Run ${chalk.bold(`mcpc ${target} tasks-result <taskId>`)} to fetch the final result of a task`
+          )
+        );
       }
     } else {
       console.log(formatOutput({ tasks: allTasks }, 'json'));

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -9,6 +9,35 @@ import { withMcpClient } from '../helpers.js';
 import { formatTask, formatTasks } from '../output.js';
 
 /**
+ * Get the final result of a task (wraps MCP `tasks/result`).
+ * Blocks on the server until the task reaches a terminal state, then prints
+ * the `CallToolResult` payload using the same renderer as `tools-call`.
+ */
+export async function getTaskResult(
+  target: string,
+  taskId: string,
+  options: CommandOptions
+): Promise<void> {
+  await withMcpClient(target, options, async (client, _context) => {
+    const result = await client.getTaskResult(taskId);
+
+    if (options.outputMode === 'human') {
+      if (result.isError) {
+        console.log(formatError(`Task ${taskId} returned an error`));
+      } else {
+        console.log(formatSuccess(`Task ${taskId} result`));
+      }
+    }
+
+    console.log(
+      formatOutput(result, options.outputMode, {
+        ...(options.maxChars && { maxChars: options.maxChars }),
+      })
+    );
+  });
+}
+
+/**
  * List active tasks on the server
  */
 export async function listTasks(target: string, options: CommandOptions): Promise<void> {

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -51,7 +51,7 @@ export async function listTasks(target: string, options: CommandOptions): Promis
         console.log(formatTasks(allTasks));
         console.log(
           formatInfo(
-            `Run ${chalk.bold(`mcpc ${target} tasks-result <taskId>`)} to fetch the final result of a task`
+            `Run ${chalk.bold(`mcpc ${target} tasks-result <taskId>`)} to fetch the task's final result (blocks until it finishes)`
           )
         );
       }

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -4,7 +4,7 @@
  */
 
 import chalk from 'chalk';
-import { formatOutput, formatSuccess, formatError, formatInfo } from '../output.js';
+import { formatOutput, formatSuccess, formatError } from '../output.js';
 import type { CommandOptions } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 import { formatTask, formatTasks } from '../output.js';
@@ -50,8 +50,8 @@ export async function listTasks(target: string, options: CommandOptions): Promis
       } else {
         console.log(formatTasks(allTasks));
         console.log(
-          formatInfo(
-            `Run ${chalk.bold(`mcpc ${target} tasks-result <taskId>`)} to fetch the task's final result (blocks until it finishes)`
+          chalk.dim(
+            `To fetch the task's final result, run:\n  mcpc ${target} tasks-result <taskId>`
           )
         );
       }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -304,7 +304,7 @@ export async function callTool(
         console.log(formatSuccess(`Task started: ${taskUpdate.taskId}`));
         console.log(
           formatInfo(
-            `Run ${chalk.bold(`mcpc ${target} tasks-result ${taskUpdate.taskId}`)} to fetch the result once the task completes`
+            `Run ${chalk.bold(`mcpc ${target} tasks-result ${taskUpdate.taskId}`)} to fetch the task's final result (blocks until it finishes)`
           )
         );
       } else {
@@ -379,7 +379,7 @@ export async function callTool(
             if (options.outputMode === 'human') {
               console.log(
                 formatInfo(
-                  `Run ${chalk.bold(`mcpc ${target} tasks-result ${capturedTaskId!}`)} to fetch the result once the task completes`
+                  `Run ${chalk.bold(`mcpc ${target} tasks-result ${capturedTaskId!}`)} to fetch the task's final result (blocks until it finishes)`
                 )
               );
             }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -303,8 +303,8 @@ export async function callTool(
       if (options.outputMode === 'human') {
         console.log(formatSuccess(`Task started: ${taskUpdate.taskId}`));
         console.log(
-          formatInfo(
-            `Run ${chalk.bold(`mcpc ${target} tasks-result ${taskUpdate.taskId}`)} to fetch the task's final result (blocks until it finishes)`
+          chalk.dim(
+            `To fetch the task's final result, run:\n  mcpc ${target} tasks-result ${taskUpdate.taskId}`
           )
         );
       } else {
@@ -378,8 +378,8 @@ export async function callTool(
             }
             if (options.outputMode === 'human') {
               console.log(
-                formatInfo(
-                  `Run ${chalk.bold(`mcpc ${target} tasks-result ${capturedTaskId!}`)} to fetch the task's final result (blocks until it finishes)`
+                chalk.dim(
+                  `To fetch the task's final result, run:\n  mcpc ${target} tasks-result ${capturedTaskId!}`
                 )
               );
             }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -303,9 +303,7 @@ export async function callTool(
       if (options.outputMode === 'human') {
         console.log(formatSuccess(`Task started: ${taskUpdate.taskId}`));
         console.log(
-          chalk.dim(
-            `To fetch the task's final result, run:\n  mcpc ${target} tasks-result ${taskUpdate.taskId}`
-          )
+          `\nTo fetch the task's final result, run:\n  mcpc ${target} tasks-result ${taskUpdate.taskId}`
         );
       } else {
         console.log(formatOutput({ taskId: taskUpdate.taskId, status: taskUpdate.status }, 'json'));
@@ -378,9 +376,7 @@ export async function callTool(
             }
             if (options.outputMode === 'human') {
               console.log(
-                chalk.dim(
-                  `To fetch the task's final result, run:\n  mcpc ${target} tasks-result ${capturedTaskId!}`
-                )
+                `\nTo fetch the task's final result, run:\n  mcpc ${target} tasks-result ${capturedTaskId!}`
               );
             }
             return;

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -14,7 +14,7 @@ import {
   formatInfo,
 } from '../output.js';
 import { ClientError } from '../../lib/errors.js';
-import type { CommandOptions, TaskUpdate } from '../../lib/types.js';
+import type { CallToolResult, CommandOptions, TaskUpdate } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 import { parseCommandArgs, hasStdinData, readStdinArgs } from '../parser.js';
 import {
@@ -24,6 +24,45 @@ import {
   type ToolSchema,
   type SchemaMode,
 } from '../../lib/schema-validator.js';
+
+/**
+ * Render a `CallToolResult` payload using the same renderer as `tools-call`.
+ *
+ * In human mode, prints a success/error banner before the payload and an
+ * optional hint after errors. In `--json` mode, only the raw payload is
+ * printed. Honors `--max-chars` truncation.
+ *
+ * Shared by `tools-call` and `tasks-result` so both commands render results
+ * identically.
+ */
+export function renderCallToolResult(
+  result: CallToolResult,
+  options: Pick<CommandOptions, 'outputMode' | 'maxChars'>,
+  banners?: {
+    success?: string;
+    error?: string;
+    /** Hint shown only in human mode when the result is an error */
+    errorHint?: string;
+  }
+): void {
+  if (options.outputMode === 'human' && banners) {
+    if (result.isError && banners.error) {
+      console.log(formatError(banners.error));
+    } else if (!result.isError && banners.success) {
+      console.log(formatSuccess(banners.success));
+    }
+  }
+
+  console.log(
+    formatOutput(result, options.outputMode, {
+      ...(options.maxChars && { maxChars: options.maxChars }),
+    })
+  );
+
+  if (result.isError && options.outputMode === 'human' && banners?.errorHint) {
+    console.log(formatInfo(banners.errorHint));
+  }
+}
 
 /**
  * List available tools
@@ -361,28 +400,17 @@ export async function callTool(
     } else {
       // Synchronous execution (default)
       result = await client.callTool(name, parsedArgs);
-      if (options.outputMode === 'human') {
-        if (result.isError) {
-          console.log(formatError(`Tool ${name} returned an error`));
-        } else {
-          console.log(formatSuccess(`Tool ${name} executed successfully`));
-        }
-      }
     }
 
-    console.log(
-      formatOutput(result, options.outputMode, {
-        ...(options.maxChars && { maxChars: options.maxChars }),
-      })
-    );
-
-    // Show hint for getting tool schema when the tool returned an error
-    if (result.isError && options.outputMode === 'human') {
-      console.log(
-        formatInfo(
-          `Run ${chalk.bold(`mcpc ${target} tools-get ${name}`)} to see the tool schema and usage`
-        )
-      );
-    }
+    // Render the result using the shared CallToolResult renderer.
+    // The --task branch already shows success/fail via spinner, so suppress
+    // the duplicate banners in that case.
+    renderCallToolResult(result, options, {
+      ...(!useTask && {
+        success: `Tool ${name} executed successfully`,
+        error: `Tool ${name} returned an error`,
+      }),
+      errorHint: `Run ${chalk.bold(`mcpc ${target} tools-get ${name}`)} to see the tool schema and usage`,
+    });
   });
 }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -302,6 +302,11 @@ export async function callTool(
 
       if (options.outputMode === 'human') {
         console.log(formatSuccess(`Task started: ${taskUpdate.taskId}`));
+        console.log(
+          formatInfo(
+            `Run ${chalk.bold(`mcpc ${target} tasks-result ${taskUpdate.taskId}`)} to fetch the result once the task completes`
+          )
+        );
       } else {
         console.log(formatOutput({ taskId: taskUpdate.taskId, status: taskUpdate.status }, 'json'));
       }
@@ -370,6 +375,13 @@ export async function callTool(
             if (timerInterval) clearInterval(timerInterval);
             if (spinner) {
               spinner.info(`Detached. Task ${chalk.bold(capturedTaskId!)} continues in background`);
+            }
+            if (options.outputMode === 'human') {
+              console.log(
+                formatInfo(
+                  `Run ${chalk.bold(`mcpc ${target} tasks-result ${capturedTaskId!}`)} to fetch the result once the task completes`
+                )
+              );
             }
             return;
           }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -26,7 +26,7 @@ import {
 } from '../../lib/schema-validator.js';
 
 /**
- * Render a `CallToolResult` payload using the same renderer as `tools-call`.
+ * Render a `CallToolResult` payload.
  *
  * In human mode, prints a success/error banner before the payload and an
  * optional hint after errors. In `--json` mode, only the raw payload is

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -948,7 +948,13 @@ ${jsonHelp(
       await tools.getTool(session, name, getOptionsFromCommand(command));
     });
 
-  // Keep jsonHelp() consistent with tasks-result!
+  // Keep jsonHelp() consistent across tools-call and tasks-result!
+  const toolsCallJsonHelp = jsonHelp(
+    '`CallToolResult` object',
+    '`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }`',
+    `${SCHEMA_BASE}#calltoolresult`
+  );
+
   program
     .command('tools-call <name> [args...]')
     .description('Call an MCP tool with arguments.')
@@ -971,7 +977,7 @@ ${chalk.bold('Arguments:')}
 ${chalk.bold('Schema validation:')}
   --schema <file>       Validate tool schema before calling (save with tools-get --json)
   --schema-mode <mode>  strict | compatible (default) | ignore
-${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }`', `${SCHEMA_BASE}#calltoolresult`)}`
+${toolsCallJsonHelp}`
     )
     .action(async (name, args, options, command) => {
       // Intercept --help: with helpOption(false) Commander won't catch it.
@@ -1028,14 +1034,7 @@ ${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isErr
   program
     .command('tasks-result <taskId>')
     .description('Get MCP task final result (blocks until task reaches a terminal state).')
-    .addHelpText(
-      'after',
-      `
-Blocks on the server until the task reaches a terminal state (completed,
-failed, or cancelled), then prints the ${chalk.bold('CallToolResult')} payload using the
-same renderer as ${chalk.bold('tools-call')}.
-${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }`', `${SCHEMA_BASE}#calltoolresult`)}`
-    )
+    .addHelpText('after', toolsCallJsonHelp)
     .action(async (taskId, _options, command) => {
       await tasks.getTaskResult(session, taskId, getOptionsFromCommand(command));
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -421,6 +421,7 @@ ${chalk.bold('MCP session commands (after connecting):')}
   <@session> ${chalk.cyan('resources-templates-list')}
   <@session> ${chalk.cyan('tasks-list')}
   <@session> ${chalk.cyan('tasks-get')} <taskId>
+  <@session> ${chalk.cyan('tasks-result')} <taskId>
   <@session> ${chalk.cyan('tasks-cancel')} <taskId>
   <@session> ${chalk.cyan('logging-set-level')} <level>
   <@session> ${chalk.cyan('ping')}
@@ -1020,6 +1021,21 @@ ${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isErr
     )
     .action(async (taskId, _options, command) => {
       await tasks.getTask(session, taskId, getOptionsFromCommand(command));
+    });
+
+  program
+    .command('tasks-result <taskId>')
+    .description('Get MCP task final result (blocks until task reaches a terminal state).')
+    .addHelpText(
+      'after',
+      jsonHelp(
+        '`CallToolResult` object',
+        '`{ content: [...], structuredContent?, isError? }`',
+        `${SCHEMA_BASE}#calltoolresult`
+      )
+    )
+    .action(async (taskId, _options, command) => {
+      await tasks.getTaskResult(session, taskId, getOptionsFromCommand(command));
     });
 
   program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1030,7 +1030,6 @@ ${toolsCallJsonHelp}`
       await tasks.getTask(session, taskId, getOptionsFromCommand(command));
     });
 
-  // Keep jsonHelp() consistent with tools-call!
   program
     .command('tasks-result <taskId>')
     .description('Get MCP task final result (blocks until task reaches a terminal state).')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -970,7 +970,7 @@ ${chalk.bold('Arguments:')}
 ${chalk.bold('Schema validation:')}
   --schema <file>       Validate tool schema before calling (save with tools-get --json)
   --schema-mode <mode>  strict | compatible (default) | ignore
-${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isError?, structuredContent? }`', `${SCHEMA_BASE}#calltoolresult`)}`
+${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }`', `${SCHEMA_BASE}#calltoolresult`)}`
     )
     .action(async (name, args, options, command) => {
       // Intercept --help: with helpOption(false) Commander won't catch it.
@@ -1030,7 +1030,8 @@ ${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isErr
       'after',
       jsonHelp(
         '`CallToolResult` object',
-        '`{ content: [...], structuredContent?, isError? }`',
+        // Keep this consistent with tools-call!
+        '`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }`',
         `${SCHEMA_BASE}#calltoolresult`
       )
     )

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1028,11 +1028,11 @@ ${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isErr
     .description('Get MCP task final result (blocks until task reaches a terminal state).')
     .addHelpText(
       'after',
-      jsonHelp(
-        '`CallToolResult` object',
-        '`{ content: [...], structuredContent?, isError? }`',
-        `${SCHEMA_BASE}#calltoolresult`
-      )
+      `
+Blocks on the server until the task reaches a terminal state (completed,
+failed, or cancelled), then prints the ${chalk.bold('CallToolResult')} payload using the
+same renderer as ${chalk.bold('tools-call')}.
+${jsonHelp('`CallToolResult` object', '`{ content: [{ type, text?, ... }], isError?, structuredContent? }`', `${SCHEMA_BASE}#calltoolresult`)}`
     )
     .action(async (taskId, _options, command) => {
       await tasks.getTaskResult(session, taskId, getOptionsFromCommand(command));

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1310,6 +1310,7 @@ export function formatServerDetails(
   if (capabilities?.tasks) {
     commands.push(`${bullet} ${bt}mcpc ${target} tasks-list${bt}`);
     commands.push(`${bullet} ${bt}mcpc ${target} tasks-get <taskId>${bt}`);
+    commands.push(`${bullet} ${bt}mcpc ${target} tasks-result <taskId>${bt}`);
     commands.push(`${bullet} ${bt}mcpc ${target} tasks-cancel <taskId>${bt}`);
   }
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -110,6 +110,7 @@ export const KNOWN_SESSION_COMMANDS = [
   'ping',
   'tasks-list',
   'tasks-get',
+  'tasks-result',
   'tasks-cancel',
   'grep',
 ];

--- a/src/cli/shell.ts
+++ b/src/cli/shell.ts
@@ -320,6 +320,16 @@ async function executeCommand(ctx: ShellContext, line: string): Promise<void> {
         break;
       }
 
+      case 'tasks-result': {
+        if (args.length === 0) {
+          console.log(chalk.red('Error: tasks-result requires a task ID'));
+          console.log('Usage: tasks-result <taskId>');
+          return;
+        }
+        await tasks.getTaskResult(ctx.target, args[0] as string, options);
+        break;
+      }
+
       case 'tasks-cancel': {
         if (args.length === 0) {
           console.log(chalk.red('Error: tasks-cancel requires a task ID'));

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -773,6 +773,29 @@ export class McpClient implements IMcpClient {
   }
 
   /**
+   * Get the final result of a task.
+   * Blocks on the server until the task reaches a terminal state, per
+   * the MCP `tasks/result` protocol method.
+   */
+  async getTaskResult(taskId: string): Promise<CallToolResult> {
+    try {
+      this.logger.debug(`Getting task result: ${taskId}`);
+      const result = (await this.client.experimental.tasks.getTaskResult(
+        taskId,
+        CallToolResultSchema,
+        this.getRequestOptions()
+      )) as CallToolResult;
+      this.logger.debug(`Task ${taskId} result received`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Failed to get task result ${taskId}:`, error);
+      throw new ServerError(`Failed to get task result ${taskId}: ${(error as Error).message}`, {
+        originalError: error,
+      });
+    }
+  }
+
+  /**
    * Cancel a running task
    */
   async cancelTask(taskId: string): Promise<CancelTaskResult> {

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -433,6 +433,18 @@ export class SessionClient extends EventEmitter implements IMcpClient {
     );
   }
 
+  async getTaskResult(taskId: string): Promise<CallToolResult> {
+    return this.withRetry(
+      () =>
+        this.bridgeClient.request(
+          'getTaskResult',
+          { taskId },
+          this.requestTimeout
+        ) as Promise<CallToolResult>,
+      'getTaskResult'
+    );
+  }
+
   async cancelTask(taskId: string): Promise<CancelTaskResult> {
     return this.withRetry(
       () =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -413,5 +413,6 @@ export interface IMcpClient {
   pollTask(taskId: string, onUpdate?: (update: TaskUpdate) => void): Promise<CallToolResult>;
   listTasks(cursor?: string): Promise<ListTasksResult>;
   getTask(taskId: string): Promise<GetTaskResult>;
+  getTaskResult(taskId: string): Promise<CallToolResult>;
   cancelTask(taskId: string): Promise<CancelTaskResult>;
 }

--- a/test/e2e/suites/sessions/async-tasks.test.sh
+++ b/test/e2e/suites/sessions/async-tasks.test.sh
@@ -119,6 +119,36 @@ assert_json_eq "$STDOUT" '.status' 'completed'
 assert_contains "$STDOUT" "Done (2 steps)"
 test_pass
 
+# ── tasks-result (fetch final CallToolResult payload) ────────
+
+test_case "tasks-result returns the CallToolResult payload"
+run_mcpc "$SESSION" tasks-result "$WAIT_TASK_ID"
+assert_success
+assert_contains "$STDOUT" "Completed 2 steps in 500ms"
+test_pass
+
+test_case "tasks-result --json returns the raw CallToolResult"
+run_mcpc --json "$SESSION" tasks-result "$WAIT_TASK_ID"
+assert_success
+assert_json_valid "$STDOUT"
+assert_contains "$STDOUT" "Completed 2 steps in 500ms"
+# The payload is a CallToolResult, so it must contain a content[] array
+content_type=$(echo "$STDOUT" | jq -r '.content[0].type')
+assert_eq "$content_type" "text"
+test_pass
+
+test_case "tasks-result blocks until the task reaches a terminal state"
+# Start a task that takes ~1.5 seconds and immediately ask for its result
+run_mcpc --json "$SESSION" tools-call --detach slow-task ms:=1500 steps:=3
+assert_success
+RESULT_TASK_ID=$(echo "$STDOUT" | jq -r '.taskId')
+# This should block on the server until the task completes, then return the payload
+run_mcpc --json "$SESSION" tasks-result "$RESULT_TASK_ID"
+assert_success
+assert_json_valid "$STDOUT"
+assert_contains "$STDOUT" "Completed 3 steps in 1500ms"
+test_pass
+
 # ── Synchronous fallback (no --task) ─────────────────────────
 
 test_case "tools-call without --task runs synchronously"


### PR DESCRIPTION
## Summary
This PR adds a new `tasks-result <taskId>` command that fetches the final `CallToolResult` payload of an async task via the MCP `tasks/result` protocol method. The command blocks on the server until the task reaches a terminal state before returning the result.

Fixes https://github.com/apify/mcpc/issues/168

## Key Changes
- **New CLI command**: `tasks-result <taskId>` - fetches and displays the final result of an async task
  - Blocks until the task reaches a terminal state (per MCP spec)
  - Outputs formatted result in human-readable mode or raw JSON with `--json` flag
  - Uses the same output renderer as `tools-call` for consistency
  
- **Core client implementation**: Added `getTaskResult()` method to `McpClient` that wraps the MCP `tasks/result` protocol method

- **Session client support**: Added `getTaskResult()` to `SessionClient` for bridge communication

- **Bridge process**: Added handler for `getTaskResult` RPC calls

- **Shell integration**: Added `tasks-result` command support in interactive shell mode

- **Documentation updates**:
  - Updated help text and README with new command
  - Added usage examples in async tasks documentation
  - Updated CHANGELOG with feature description

- **Test coverage**: Added comprehensive e2e tests covering:
  - Basic result fetching with human and JSON output modes
  - Blocking behavior until task completion
  - Proper `CallToolResult` payload validation

## Implementation Details
- The command integrates seamlessly with existing task infrastructure, reusing the same output formatting as `tools-call`
- Properly handles both successful and error task results
- Maintains consistency with other task commands (`tasks-list`, `tasks-get`, `tasks-cancel`)
- Includes proper error handling and logging throughout the call chain

https://claude.ai/code/session_01KxvJ6iKNXMtWv429TA8huH