### PR TITLE
Shell-quote JSON values in tool call examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `tools-get` "Call example" now wraps JSON values (arrays, objects, strings) in single quotes so they can be copy-pasted into a shell verbatim without being mangled by word-splitting (e.g., `outputFormats:='["markdown"]'` instead of `outputFormats:=["markdown"]`)
+
 ## [0.2.5] - 2026-04-15
 
 ### Added

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -630,6 +630,25 @@ function exampleValue(propSchema: Record<string, unknown>): string {
 }
 
 /**
+ * Wrap a JSON-stringified example value in single quotes if it contains
+ * characters that would be mangled by a POSIX shell (double quotes, brackets,
+ * braces, spaces, etc.). This ensures the "Call example" line can be
+ * copy-pasted into a shell verbatim and still round-trip through the parser.
+ *
+ * Without this, values like `["markdown"]` lose their inner quotes to shell
+ * word-splitting and reach mcpc as `[markdown]`, which is not valid JSON.
+ */
+function shellSafeExampleValue(jsonValue: string): string {
+  // Numbers, booleans, null, and simple identifier-like tokens are safe as-is.
+  if (/^[a-zA-Z0-9_.+-]+$/.test(jsonValue)) {
+    return jsonValue;
+  }
+  // Single-quote the value, escaping any embedded single quotes using the
+  // POSIX-portable `'\''` trick.
+  return `'${jsonValue.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Format a tools-call usage example for a tool, showing how to invoke it.
  * Shows required params first, then fills with optional params up to 3 total.
  */
@@ -665,7 +684,7 @@ export function formatToolCallExample(tool: Tool, sessionName?: string): string 
   }
 
   const argParts = params.map((name) => {
-    const val = exampleValue(properties[name] ?? {});
+    const val = shellSafeExampleValue(exampleValue(properties[name] ?? {}));
     return `${name}:=${val}`;
   });
 

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -849,8 +849,8 @@ describe('formatToolCallExample', () => {
     expect(output).not.toBeNull();
     expect(output).toContain('tools-call read_file');
     expect(output).toContain('@fs');
-    expect(output).toContain('path:="something"');
-    expect(output).toContain('encoding:="utf-8"');
+    expect(output).toContain(`path:='"something"'`);
+    expect(output).toContain(`encoding:='"utf-8"'`);
     expect(output).toContain('tail:=0');
   });
 
@@ -868,7 +868,7 @@ describe('formatToolCallExample', () => {
     };
 
     const output = formatToolCallExample(tool, '@test');
-    expect(output).toContain('query:="something"');
+    expect(output).toContain(`query:='"something"'`);
     expect(output).toContain('limit:=10');
   });
 
@@ -898,7 +898,7 @@ describe('formatToolCallExample', () => {
     };
 
     const output = formatToolCallExample(tool, '@s');
-    expect(output).toContain('mode:="fast"');
+    expect(output).toContain(`mode:='"fast"'`);
   });
 
   it('should use placeholder <@session> when no session name provided', () => {
@@ -932,6 +932,42 @@ describe('formatToolCallExample', () => {
 
     const output = formatToolCallExample(tool, '@s');
     expect(output).toContain('[--task]');
+  });
+
+  it('should shell-quote array default values so they survive shell parsing', () => {
+    // Regression: array defaults like ["markdown"] were being rendered without
+    // shell quoting, so the shell stripped the inner double quotes and mcpc
+    // received `[markdown]`, which is not valid JSON.
+    const tool: Tool = {
+      name: 'rag-web-browser',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+          outputFormats: { type: 'array', default: ['markdown'] },
+        },
+        required: ['query'],
+      },
+    };
+
+    const output = formatToolCallExample(tool, '@apify');
+    expect(output).toContain(`outputFormats:='["markdown"]'`);
+  });
+
+  it('should shell-quote object default values', () => {
+    const tool: Tool = {
+      name: 'configure',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          config: { type: 'object', default: { key: 'value' } },
+        },
+        required: ['config'],
+      },
+    };
+
+    const output = formatToolCallExample(tool, '@s');
+    expect(output).toContain(`config:='{"key":"value"}'`);
   });
 });
 


### PR DESCRIPTION
## Summary
Fix the "Call example" output in `tools-get` to properly shell-quote JSON values (arrays, objects, and strings) so they can be safely copy-pasted into a shell without being mangled by word-splitting.

## Changes
- Added `shellSafeExampleValue()` function that wraps JSON-stringified values in single quotes when they contain shell-special characters (brackets, braces, spaces, quotes, etc.)
- Updated `formatToolCallExample()` to use `shellSafeExampleValue()` when generating parameter examples
- The function preserves simple values (numbers, booleans, null, identifiers) as-is for readability
- Properly escapes embedded single quotes using the POSIX-portable `'\''` technique

## Implementation Details
The fix ensures that complex default values like `["markdown"]` are rendered as `outputFormats:='["markdown"]'` instead of `outputFormats:=["markdown"]`, preventing the shell from stripping the inner quotes and causing invalid JSON to reach the parser.

Updated test expectations to match the new quoting behavior and added regression tests for array and object default values.

https://claude.ai/code/session_01MocusWPNsL6TBFdAYBLyJx