### PR TITLE
Print task ID on Ctrl+C interrupt for async tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `tools-call --task` now prints the task ID and recovery commands when interrupted with Ctrl+C, so you can fetch or cancel the server-side task later
+
 ## [0.2.6] - 2026-04-15
 
 ### Added

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -3,7 +3,7 @@
  * Manage async tasks on MCP servers that support the tasks capability
  */
 
-import { formatOutput, formatSuccess, formatError } from '../output.js';
+import { formatOutput, formatSuccess, formatError, formatTaskCommandsHint } from '../output.js';
 import type { CommandOptions } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 import { formatTask, formatTasks } from '../output.js';
@@ -48,9 +48,7 @@ export async function listTasks(target: string, options: CommandOptions): Promis
         console.log(formatSuccess('No active tasks'));
       } else {
         console.log(formatTasks(allTasks));
-        console.log(
-          `\nTo fetch the task's final result, run:\n  mcpc ${target} tasks-result <taskId>`
-        );
+        console.log(formatTaskCommandsHint(target));
       }
     } else {
       console.log(formatOutput({ tasks: allTasks }, 'json'));
@@ -71,6 +69,7 @@ export async function getTask(
 
     if (options.outputMode === 'human') {
       console.log(formatTask(result));
+      console.log(formatTaskCommandsHint(target, taskId));
     } else {
       console.log(formatOutput(result, 'json'));
     }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -326,15 +326,22 @@ export async function callTool(
 
       const escHintText = escListener.promise ? ` ${chalk.dim('(ESC to detach)')}` : '';
 
+      const printDetachedHint = (taskId: string): void => {
+        if (spinner) {
+          spinner.info(`Detached. Task ${chalk.bold(`\`${taskId}\``)} continues in background`);
+        }
+        console.log(
+          `\nTo wait for the task and fetch its result, run:\n  mcpc ${target} tasks-result ${taskId}`
+        );
+        console.log(`\nTo cancel the task, run:\n  mcpc ${target} tasks-cancel ${taskId}`);
+      };
+
       // Set up SIGINT handler to print task ID hint on Ctrl+C (human mode only)
       const sigintHandler = (): void => {
         escListener.cleanup();
         if (timerInterval) clearInterval(timerInterval);
-        if (spinner) spinner.stop();
         if (capturedTaskId && options.outputMode === 'human') {
-          console.error(`\nInterrupted. Task \`${capturedTaskId}\` continues on the server.`);
-          console.error(`- \`mcpc ${target} tasks-result ${capturedTaskId}\` to fetch the result`);
-          console.error(`- \`mcpc ${target} tasks-cancel ${capturedTaskId}\` to stop it`);
+          printDetachedHint(capturedTaskId);
         }
         process.exit(0);
       };
@@ -385,14 +392,7 @@ export async function callTool(
 
           if (raceResult.type === 'detached') {
             if (timerInterval) clearInterval(timerInterval);
-            if (spinner) {
-              spinner.info(`Detached. Task ${chalk.bold(capturedTaskId!)} continues in background`);
-            }
-            if (options.outputMode === 'human') {
-              console.log(
-                `\nTo fetch the task's final result, run:\n  mcpc ${target} tasks-result ${capturedTaskId!}`
-              );
-            }
+            printDetachedHint(capturedTaskId!);
             return;
           }
 

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -12,6 +12,7 @@ import {
   formatError,
   formatWarning,
   formatInfo,
+  formatTaskCommandsHint,
 } from '../output.js';
 import { ClientError } from '../../lib/errors.js';
 import type { CallToolResult, CommandOptions, TaskUpdate } from '../../lib/types.js';
@@ -302,9 +303,7 @@ export async function callTool(
 
       if (options.outputMode === 'human') {
         console.log(formatSuccess(`Task started: ${taskUpdate.taskId}`));
-        console.log(
-          `\nTo fetch the task's final result, run:\n  mcpc ${target} tasks-result ${taskUpdate.taskId}`
-        );
+        console.log(formatTaskCommandsHint(target, taskUpdate.taskId));
       } else {
         console.log(formatOutput({ taskId: taskUpdate.taskId, status: taskUpdate.status }, 'json'));
       }
@@ -330,10 +329,7 @@ export async function callTool(
         if (spinner) {
           spinner.info(`Detached. Task ${chalk.bold(`\`${taskId}\``)} continues in background`);
         }
-        console.log(
-          `\nTo wait for the task and fetch its result, run:\n  mcpc ${target} tasks-result ${taskId}`
-        );
-        console.log(`\nTo cancel the task, run:\n  mcpc ${target} tasks-cancel ${taskId}`);
+        console.log(formatTaskCommandsHint(target, taskId));
       };
 
       // Set up SIGINT handler to print task ID hint on Ctrl+C (human mode only)

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -326,6 +326,20 @@ export async function callTool(
 
       const escHintText = escListener.promise ? ` ${chalk.dim('(ESC to detach)')}` : '';
 
+      // Set up SIGINT handler to print task ID hint on Ctrl+C (human mode only)
+      const sigintHandler = (): void => {
+        escListener.cleanup();
+        if (timerInterval) clearInterval(timerInterval);
+        if (spinner) spinner.stop();
+        if (capturedTaskId && options.outputMode === 'human') {
+          console.error(`\nInterrupted. Task \`${capturedTaskId}\` continues on the server.`);
+          console.error(`- \`mcpc ${target} tasks-result ${capturedTaskId}\` to fetch the result`);
+          console.error(`- \`mcpc ${target} tasks-cancel ${capturedTaskId}\` to stop it`);
+        }
+        process.exit(0);
+      };
+      process.on('SIGINT', sigintHandler);
+
       const updateSpinnerText = (): void => {
         if (!spinner) return;
         const elapsed = formatElapsed(Date.now() - startTime);
@@ -403,6 +417,7 @@ export async function callTool(
         }
         throw error;
       } finally {
+        process.off('SIGINT', sigintHandler);
         if (timerInterval) clearInterval(timerInterval);
       }
     } else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -955,11 +955,19 @@ ${jsonHelp(
     `${SCHEMA_BASE}#calltoolresult`
   );
 
+  const toolsCallDetachJsonHelp = jsonHelp(
+    'With `--detach`: `CreateTaskResult` object',
+    '`{ taskId: string, status: string }`'
+  );
+
   program
     .command('tools-call <name> [args...]')
     .description('Call an MCP tool with arguments.')
     .helpOption(false) // Disable built-in --help so we can intercept it for tool schema
-    .option('--task', 'Use async task execution (experimental)')
+    .option(
+      '--task',
+      'Use async task execution; Ctrl+C prints the task ID and exits (experimental)'
+    )
     .option('--detach', 'Start task and return immediately with task ID (implies --task)')
     .option('--schema <file>', 'Validate tool schema against expected schema before calling')
     .option('--schema-mode <mode>', 'Schema validation mode: strict, compatible (default), ignore')
@@ -974,10 +982,16 @@ ${chalk.bold('Arguments:')}
   Values are auto-parsed: strings, numbers, booleans, JSON objects/arrays.
   To force a string, wrap in quotes: id:='"123"'
 
+${chalk.bold('Async tasks (--task, --detach):')}
+  --task shows a progress spinner while the task runs on the server.
+  If you press Ctrl+C, the task keeps running and a hint with the task ID
+  is printed so you can fetch or cancel it later.
+  --detach returns the task ID immediately without waiting.
+
 ${chalk.bold('Schema validation:')}
   --schema <file>       Validate tool schema before calling (save with tools-get --json)
   --schema-mode <mode>  strict | compatible (default) | ignore
-${toolsCallJsonHelp}`
+${toolsCallJsonHelp}${toolsCallDetachJsonHelp}`
     )
     .action(async (name, args, options, command) => {
       // Intercept --help: with helpOption(false) Commander won't catch it.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -932,17 +932,22 @@ ${jsonHelp(
       await tools.getTool(session, name, getOptionsFromCommand(command));
     });
 
-  // Keep jsonHelp() consistent across tools-call and tasks-result!
+  // Keep the CallToolResult line consistent across tools-call and tasks-result!
   const toolsCallJsonHelp = jsonHelp(
     '`CallToolResult` object',
     '`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }`',
     `${SCHEMA_BASE}#calltoolresult`
   );
 
-  const toolsCallDetachJsonHelp = jsonHelp(
-    'With `--detach`: `CreateTaskResult` object',
-    '`{ taskId: string, status: string }`'
-  );
+  const toolsCallCombinedJsonHelp = `
+${chalk.bold('JSON output (--json):')}
+  \`CallToolResult\` object:
+  \`{ content: [{ type, text?, ... }], isError?, structuredContent?: { ... } }\`
+  Schema: ${SCHEMA_BASE}#calltoolresult
+
+  With \`--detach\`: \`CreateTaskResult\` object:
+  \`{ taskId: string, status: string }\`
+`;
 
   program
     .command('tools-call <name> [args...]')
@@ -975,7 +980,7 @@ ${chalk.bold('Async tasks (--task, --detach):')}
 ${chalk.bold('Schema validation:')}
   --schema <file>       Validate tool schema before calling (save with tools-get --json)
   --schema-mode <mode>  strict | compatible (default) | ignore
-${toolsCallJsonHelp}${toolsCallDetachJsonHelp}`
+${toolsCallCombinedJsonHelp}`
     )
     .action(async (name, args, options, command) => {
       // Intercept --help: with helpOption(false) Commander won't catch it.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -947,6 +947,7 @@ ${chalk.bold('JSON output (--json):')}
 
   With \`--detach\`: \`CreateTaskResult\` object:
   \`{ taskId: string, status: string }\`
+  Schema: ${SCHEMA_BASE}#createtaskresult
 `;
 
   program

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -971,20 +971,21 @@ function formatPromptContent(content: PromptMessage['content']): string {
 /**
  * Get a colored status indicator for a task status
  */
-function taskStatusIcon(status: string): string {
+function taskStatusLabel(status: string): string {
+  const label = (icon: string): string => `${icon} ${status}`;
   switch (status) {
     case 'working':
-      return chalk.cyan('⟳');
+      return chalk.cyan(label('⟳'));
     case 'input_required':
-      return chalk.yellow('?');
+      return chalk.yellow(label('?'));
     case 'completed':
-      return chalk.green('✔');
+      return chalk.green(label('✔'));
     case 'failed':
-      return chalk.red('✖');
+      return chalk.red(label('✖'));
     case 'cancelled':
-      return chalk.gray('⊘');
+      return chalk.gray(label('⊘'));
     default:
-      return chalk.gray('·');
+      return chalk.gray(label('·'));
   }
 }
 
@@ -994,8 +995,8 @@ function taskStatusIcon(status: string): string {
 export function formatTask(task: Task): string {
   const lines: string[] = [];
 
-  lines.push(`${chalk.bold('Task:')} ${inBackticks(task.taskId)}`);
-  lines.push(`${chalk.bold('Status:')} ${taskStatusIcon(task.status)} ${task.status}`);
+  lines.push(`${chalk.bold('Task ID:')} ${inBackticks(task.taskId)}`);
+  lines.push(`${chalk.bold('Status:')} ${taskStatusLabel(task.status)}`);
 
   if (task.statusMessage) {
     lines.push(`${chalk.bold('Message:')} ${task.statusMessage}`);
@@ -1021,7 +1022,7 @@ export function formatTasks(taskList: Task[]): string {
 
   const bullet = chalk.dim('*');
   for (const task of taskList) {
-    const statusStr = `${taskStatusIcon(task.status)} ${task.status}`;
+    const statusStr = taskStatusLabel(task.status);
     const msgStr = task.statusMessage ? chalk.dim(` - ${task.statusMessage}`) : '';
     lines.push(`${bullet} ${inBackticks(task.taskId)}  ${statusStr}${msgStr}`);
   }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1086,6 +1086,16 @@ export function formatInfo(message: string): string {
   return chalk.cyan(`ℹ ${message}`);
 }
 
+export function formatTaskCommandsHint(target: string, taskId?: string): string {
+  const id = taskId ?? '<taskId>';
+  return [
+    '\nAvailable commands:',
+    `  mcpc ${target} tasks-get ${id}`,
+    `  mcpc ${target} tasks-result ${id}`,
+    `  mcpc ${target} tasks-cancel ${id}`,
+  ].join('\n');
+}
+
 /**
  * Truncate formatted output string to maxChars, appending a notice about truncation.
  * Returns the original string if within limit.


### PR DESCRIPTION
## Summary

Closes #169.

Improves UX around async tool tasks so users never lose track of the task ID after detaching or interrupting.

### Behavior
- `tools-call --task` now installs a scoped SIGINT handler: pressing Ctrl+C after a task ID has been captured prints the task ID and the commands to fetch or cancel it. The task keeps running on the server; `tasks/cancel` is **not** sent.
- `tools-call --detach`, `tools-call --task` ESC-detach, Ctrl+C interrupt, `tasks-list`, and `tasks-get` all print the same "Available commands" hint so the user can always discover the next step:
  ```
  Available commands:
    mcpc @session tasks-get <taskId>
    mcpc @session tasks-result <taskId>
    mcpc @session tasks-cancel <taskId>
  ```
- Human mode only — `--json` output is unchanged so JSON consumers are unaffected.

### Help and docs
- `--task` flag description mentions the Ctrl+C behavior.
- `tools-call` help footer gets an **Async tasks (--task, --detach)** section.
- `tools-call` help footer documents that with `--json --detach` the result is a `CreateTaskResult` (`{ taskId, status }`) instead of `CallToolResult`.
- `CHANGELOG.md` entry under `[Unreleased] → Changed`.

### Implementation
- Shared `formatTaskCommandsHint(target, taskId?)` helper in `src/cli/output.ts`. When `taskId` is omitted it renders `<taskId>` as a placeholder.
- Shared `printDetachedHint()` closure inside `callTool()` used by both the ESC-detach and SIGINT paths to guarantee identical output.
- SIGINT handler is registered before task execution and deregistered in `finally` to avoid leaking across commands.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` — 503 tests pass
- [ ] Manual: `mcpc @session tools-call <tool> --task`, press Ctrl+C → prints task ID and commands hint
- [ ] Manual: `mcpc @session tools-call <tool> --task`, press ESC → same hint
- [ ] Manual: `mcpc @session tools-call <tool> --detach` → starts task, prints hint
- [ ] Manual: `mcpc @session tools-call <tool> --task --json`, Ctrl+C → silent (no stderr/stdout pollution)
- [ ] Manual: `mcpc @session tasks-list` and `tasks-get <id>` → show hint block

https://claude.ai/code/session_01DMuLoe25t4Fwjyun36nRFx