### PR TITLE
Remove shorthand commands and improve command suggestions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -896,22 +896,6 @@ ${jsonHelp('`{ tools?: Tool[], resources?: Resource[], prompts?: Prompt[], instr
 
   // Tools commands
   program
-    .command('tools')
-    .description('List MCP tools (shorthand for tools-list).')
-    .option('--full', 'Show full tool details including schema')
-    .addHelpText(
-      'after',
-      jsonHelp(
-        'Array of `Tool` objects',
-        '`[{ name, description?, inputSchema, annotations? }, ...]`',
-        `${SCHEMA_BASE}#tool`
-      )
-    )
-    .action(async (_options, command) => {
-      await tools.listTools(session, getOptionsFromCommand(command));
-    });
-
-  program
     .command('tools-list')
     .description('List all MCP tools.')
     .option('--full', 'Show full tool details including schema')
@@ -1055,21 +1039,6 @@ ${toolsCallJsonHelp}`
 
   // Resources commands
   program
-    .command('resources')
-    .description('List MCP resources (shorthand for resources-list).')
-    .addHelpText(
-      'after',
-      jsonHelp(
-        'Array of `Resource` objects',
-        '`[{ uri, name?, description?, mimeType? }, ...]`',
-        `${SCHEMA_BASE}#resource`
-      )
-    )
-    .action(async (_options, command) => {
-      await resources.listResources(session, getOptionsFromCommand(command));
-    });
-
-  program
     .command('resources-list')
     .description('List all MCP resources.')
     .addHelpText(
@@ -1137,21 +1106,6 @@ ${toolsCallJsonHelp}`
     });
 
   // Prompts commands
-  program
-    .command('prompts')
-    .description('List MCP prompts (shorthand for prompts-list).')
-    .addHelpText(
-      'after',
-      jsonHelp(
-        'Array of `Prompt` objects',
-        '`[{ name, description?, arguments?: [{ name, required? }] }, ...]`',
-        `${SCHEMA_BASE}#prompt`
-      )
-    )
-    .action(async (_options, command) => {
-      await prompts.listPrompts(session, getOptionsFromCommand(command));
-    });
-
   program
     .command('prompts-list')
     .description('List all MCP prompts.')

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -159,11 +159,11 @@ export function suggestCommand(
     if (reversedMatch) return reversedMatch;
   }
 
-  // Check for bare prefix (e.g., "tools" → "tools-call", "resources" → "resources-read")
+  // Check for bare prefix (e.g., "tools" → "tools-list", "resources" → "resources-list")
   const prefixSuggestions: Record<string, string> = {
-    tools: 'tools-call',
-    resources: 'resources-read',
-    prompts: 'prompts-get',
+    tools: 'tools-list',
+    resources: 'resources-list',
+    prompts: 'prompts-list',
   };
   const prefixSuggestion = prefixSuggestions[normalized];
   if (prefixSuggestion && commands.includes(prefixSuggestion)) {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -93,17 +93,14 @@ export const KNOWN_SESSION_COMMANDS = [
   'shell',
   'close',
   'restart',
-  'tools',
   'tools-list',
   'tools-get',
   'tools-call',
-  'resources',
   'resources-list',
   'resources-read',
   'resources-subscribe',
   'resources-unsubscribe',
   'resources-templates-list',
-  'prompts',
   'prompts-list',
   'prompts-get',
   'logging-set-level',
@@ -160,6 +157,17 @@ export function suggestCommand(
     const reversed = parts.reverse().join('-');
     const reversedMatch = commands.find((cmd) => cmd.toLowerCase() === reversed);
     if (reversedMatch) return reversedMatch;
+  }
+
+  // Check for bare prefix (e.g., "tools" → "tools-call", "resources" → "resources-read")
+  const prefixSuggestions: Record<string, string> = {
+    tools: 'tools-call',
+    resources: 'resources-read',
+    prompts: 'prompts-get',
+  };
+  const prefixSuggestion = prefixSuggestions[normalized];
+  if (prefixSuggestion && commands.includes(prefixSuggestion)) {
+    return prefixSuggestion;
   }
 
   // Fall back to Levenshtein distance

--- a/test/e2e/suites/basic/errors.test.sh
+++ b/test/e2e/suites/basic/errors.test.sh
@@ -52,6 +52,30 @@ assert_failure
 assert_contains "$STDERR" "Did you mean: mcpc @test tools-list"
 test_pass
 
+# Test: bare "tools" command suggests tools-call
+test_case "bare tools suggests tools-call"
+run_mcpc @test tools
+assert_failure
+assert_contains "$STDERR" "Unknown command: tools"
+assert_contains "$STDERR" "Did you mean: mcpc @test tools-call"
+test_pass
+
+# Test: bare "resources" command suggests resources-read
+test_case "bare resources suggests resources-read"
+run_mcpc @test resources
+assert_failure
+assert_contains "$STDERR" "Unknown command: resources"
+assert_contains "$STDERR" "Did you mean: mcpc @test resources-read"
+test_pass
+
+# Test: bare "prompts" command suggests prompts-get
+test_case "bare prompts suggests prompts-get"
+run_mcpc @test prompts
+assert_failure
+assert_contains "$STDERR" "Unknown command: prompts"
+assert_contains "$STDERR" "Did you mean: mcpc @test prompts-get"
+test_pass
+
 # Test: completely unknown command shows help text but no suggestion
 test_case "unknown command shows help pointer"
 run_mcpc @test xyzzy-$RANDOM
@@ -83,6 +107,14 @@ run_mcpc tools-list
 assert_failure
 assert_contains "$STDERR" "Missing session target for command: tools-list"
 assert_contains "$STDERR" "Did you mean: mcpc <@session> tools-list"
+test_pass
+
+# Test: bare "tools" without @session suggests session subcommand
+test_case "top-level bare tools suggests session subcommand"
+run_mcpc tools
+assert_failure
+assert_contains "$STDERR" "Unknown command: tools"
+assert_contains "$STDERR" "Did you mean: mcpc <@session> tools-call"
 test_pass
 
 # Test: top-level typo that matches a session subcommand

--- a/test/e2e/suites/basic/errors.test.sh
+++ b/test/e2e/suites/basic/errors.test.sh
@@ -52,28 +52,28 @@ assert_failure
 assert_contains "$STDERR" "Did you mean: mcpc @test tools-list"
 test_pass
 
-# Test: bare "tools" command suggests tools-call
-test_case "bare tools suggests tools-call"
+# Test: bare "tools" command suggests tools-list
+test_case "bare tools suggests tools-list"
 run_mcpc @test tools
 assert_failure
 assert_contains "$STDERR" "Unknown command: tools"
-assert_contains "$STDERR" "Did you mean: mcpc @test tools-call"
+assert_contains "$STDERR" "Did you mean: mcpc @test tools-list"
 test_pass
 
-# Test: bare "resources" command suggests resources-read
-test_case "bare resources suggests resources-read"
+# Test: bare "resources" command suggests resources-list
+test_case "bare resources suggests resources-list"
 run_mcpc @test resources
 assert_failure
 assert_contains "$STDERR" "Unknown command: resources"
-assert_contains "$STDERR" "Did you mean: mcpc @test resources-read"
+assert_contains "$STDERR" "Did you mean: mcpc @test resources-list"
 test_pass
 
-# Test: bare "prompts" command suggests prompts-get
-test_case "bare prompts suggests prompts-get"
+# Test: bare "prompts" command suggests prompts-list
+test_case "bare prompts suggests prompts-list"
 run_mcpc @test prompts
 assert_failure
 assert_contains "$STDERR" "Unknown command: prompts"
-assert_contains "$STDERR" "Did you mean: mcpc @test prompts-get"
+assert_contains "$STDERR" "Did you mean: mcpc @test prompts-list"
 test_pass
 
 # Test: completely unknown command shows help text but no suggestion
@@ -114,7 +114,7 @@ test_case "top-level bare tools suggests session subcommand"
 run_mcpc tools
 assert_failure
 assert_contains "$STDERR" "Unknown command: tools"
-assert_contains "$STDERR" "Did you mean: mcpc <@session> tools-call"
+assert_contains "$STDERR" "Did you mean: mcpc <@session> tools-list"
 test_pass
 
 # Test: top-level typo that matches a session subcommand

--- a/test/unit/cli/parser.test.ts
+++ b/test/unit/cli/parser.test.ts
@@ -527,13 +527,13 @@ describe('suggestCommand', () => {
     expect(suggestCommand('list-prompts', commands)).toBe('prompts-list');
   });
 
-  it('suggests action command for bare prefix (tools, resources, prompts)', () => {
-    expect(suggestCommand('tools', commands)).toBe('tools-call');
-    expect(suggestCommand('resources', commands)).toBe('resources-read');
-    expect(suggestCommand('prompts', commands)).toBe('prompts-get');
+  it('suggests list command for bare prefix (tools, resources, prompts)', () => {
+    expect(suggestCommand('tools', commands)).toBe('tools-list');
+    expect(suggestCommand('resources', commands)).toBe('resources-list');
+    expect(suggestCommand('prompts', commands)).toBe('prompts-list');
     // Case-insensitive
-    expect(suggestCommand('TOOLS', commands)).toBe('tools-call');
-    expect(suggestCommand('Resources', commands)).toBe('resources-read');
+    expect(suggestCommand('TOOLS', commands)).toBe('tools-list');
+    expect(suggestCommand('Resources', commands)).toBe('resources-list');
   });
 
   it('suggests the closest match for typos', () => {

--- a/test/unit/cli/parser.test.ts
+++ b/test/unit/cli/parser.test.ts
@@ -527,6 +527,15 @@ describe('suggestCommand', () => {
     expect(suggestCommand('list-prompts', commands)).toBe('prompts-list');
   });
 
+  it('suggests action command for bare prefix (tools, resources, prompts)', () => {
+    expect(suggestCommand('tools', commands)).toBe('tools-call');
+    expect(suggestCommand('resources', commands)).toBe('resources-read');
+    expect(suggestCommand('prompts', commands)).toBe('prompts-get');
+    // Case-insensitive
+    expect(suggestCommand('TOOLS', commands)).toBe('tools-call');
+    expect(suggestCommand('Resources', commands)).toBe('resources-read');
+  });
+
   it('suggests the closest match for typos', () => {
     expect(suggestCommand('tools-lst', commands)).toBe('tools-list');
     expect(suggestCommand('conect', commands)).toBe('connect');


### PR DESCRIPTION
## Summary
This PR removes the shorthand `tools`, `resources`, and `prompts` commands and improves the command suggestion system to guide users to the full command names when they use the bare prefixes.

## Key Changes
- **Removed shorthand commands**: Deleted the `tools`, `resources`, and `prompts` commands from the CLI, keeping only their full variants (`tools-list`, `resources-list`, `prompts-list`)
- **Updated command registry**: Removed the three shorthand commands from `KNOWN_SESSION_COMMANDS` in the parser
- **Enhanced command suggestions**: Added prefix-matching logic to `suggestCommand()` that suggests the appropriate `-list` variant when users type bare prefixes (e.g., `tools` → `tools-list`)
- **Added test coverage**: Added unit tests for the new prefix suggestion behavior and e2e tests verifying that bare commands fail with helpful suggestions

## Implementation Details
The command suggestion system now includes a new prefix-matching step that checks if an unknown command matches one of the known bare prefixes (`tools`, `resources`, `prompts`) and suggests the corresponding `-list` command. This provides a better user experience by guiding users to the correct command without requiring them to remember the full naming convention.

The prefix matching is case-insensitive and runs before the Levenshtein distance fallback, ensuring that exact prefix matches are prioritized over fuzzy matching.

https://claude.ai/code/session_01CtojWxD6727Ba3vERgXxyk