### PR TITLE
Simplify session/target output by removing transport type labels

### DIFF
--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -865,7 +865,7 @@ export async function restartSession(
       console.log(formatSuccess(`Session ${name} restarted`));
       console.log(
         chalk.dim(
-          '  Note: previous session state (resource subscriptions, pending notifications, async tasks) was lost'
+          'Note: previous session state was lost (e.g. added tools, resource subscriptions, async tasks)'
         )
       );
     }

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -9,7 +9,7 @@ import { normalizeServerUrl, isValidSessionName, getServerHost } from '../lib/ut
 import { setVerbose, createLogger } from '../lib/logger.js';
 import { loadConfig, getServerConfig, validateServerConfig } from '../lib/config.js';
 import { getAuthProfile } from '../lib/auth/profiles.js';
-import { logTarget } from './output.js';
+import { formatSessionLine } from './output.js';
 import { DEFAULT_AUTH_PROFILE } from '../lib/auth/oauth-utils.js';
 import { parseHeaderFlags } from './parser.js';
 
@@ -181,11 +181,8 @@ export async function withMcpClient<T>(
   };
 
   // Log target prefix (unless hidden)
-  if (options.outputMode) {
-    await logTarget(target, {
-      outputMode: options.outputMode,
-      hide: options.hideTarget,
-    });
+  if (options.outputMode === 'human' && !options.hideTarget && session) {
+    console.log(`[${formatSessionLine(session)}]\n`);
   }
 
   // Use session client (SessionClient implements IMcpClient interface)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1248,6 +1248,7 @@ async function handleSessionCommands(session: string, args: string[]): Promise<v
   }
 
   const program = createSessionProgram();
+  program.name(`mcpc ${session}`);
 
   // Override exit so Commander throws instead of calling process.exit()
   program.exitOverride();

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1129,19 +1129,11 @@ export function formatSessionLine(session: SessionData): string {
   }
   const targetStr = truncateWithEllipsis(target, 80);
 
-  // Format transport/auth info
-  const parts: string[] = [];
-
-  if (session.server.command) {
-    parts.push('stdio');
-  } else {
-    parts.push('HTTP');
-    if (session.profileName) {
-      parts.push('OAuth: ' + chalk.magenta(session.profileName) + chalk.dim(''));
-    }
+  // Format auth info (transport type omitted — obvious from context)
+  let infoStr = '';
+  if (!session.server.command && session.profileName) {
+    infoStr = chalk.dim('(OAuth: ') + chalk.magenta(session.profileName) + chalk.dim(')');
   }
-
-  const infoStr = chalk.dim('(') + chalk.dim(parts.join(', ')) + chalk.dim(')');
 
   // Add proxy info separately (not dimmed, for visibility)
   let proxyStr = '';
@@ -1153,7 +1145,8 @@ export function formatSessionLine(session: SessionData): string {
       chalk.green(']');
   }
 
-  return `${nameStr} → ${targetStr} ${infoStr}${proxyStr}`;
+  const suffix = [infoStr, proxyStr].filter(Boolean).join(' ');
+  return `${nameStr} → ${targetStr}${suffix ? ' ' + suffix : ''}`;
 }
 
 /**
@@ -1168,8 +1161,8 @@ export interface LogTargetOptions {
 
 /**
  * Log target prefix (only in human mode)
- * For sessions: [@name → server (transport, auth)]
- * For direct connections: [target (transport, auth)]
+ * For sessions: [@name → server (auth)]
+ * For direct connections: [target (auth)]
  */
 export async function logTarget(target: string, options: LogTargetOptions): Promise<void> {
   if (options.outputMode !== 'human' || options.hide) {
@@ -1195,17 +1188,19 @@ export async function logTarget(target: string, options: LogTargetOptions): Prom
       targetStr += ' ' + tc.args.join(' ');
     }
     targetStr = truncateWithEllipsis(targetStr, 80);
-    console.log(`[→ ${targetStr} ${chalk.dim('(stdio)')}]`);
+    console.log(`[→ ${targetStr}]`);
     return;
   }
 
   // HTTP transport: show server URL with auth info
   const serverStr = tc?.url || target;
-  const parts: string[] = ['HTTP'];
   if (options.profileName) {
-    parts.push('OAuth: ' + chalk.magenta(options.profileName));
+    console.log(
+      `[→ ${serverStr} ${chalk.dim('(OAuth: ') + chalk.magenta(options.profileName) + chalk.dim(')')}]\n`
+    );
+  } else {
+    console.log(`[→ ${serverStr}]\n`);
   }
-  console.log(`[→ ${serverStr} ${chalk.dim('(' + parts.join(', ') + ')')}]\n`);
 }
 
 /**

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -11,7 +11,7 @@ import type {
   PromptMessage,
   ContentBlock,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { OutputMode, ServerConfig } from '../lib/index.js';
+import type { OutputMode } from '../lib/index.js';
 import type {
   Tool,
   Resource,
@@ -23,7 +23,7 @@ import type {
 } from '../lib/types.js';
 import { extractSingleTextContent } from './tool-result.js';
 import { join } from 'node:path';
-import { isValidSessionName, getLogsDir } from '../lib/utils.js';
+import { getLogsDir } from '../lib/utils.js';
 import { getSession } from '../lib/sessions.js';
 
 // Re-export for external use
@@ -1109,7 +1109,7 @@ function truncateWithEllipsis(str: string, maxLen: number): string {
 
 /**
  * Format a session line for display (without status)
- * Returns: "@name → target (transport, MCP: version)" with colors applied
+ * Returns: "@name → target (OAuth: profile)" with colors applied
  */
 export function formatSessionLine(session: SessionData): string {
   // Format session name (cyan)
@@ -1155,52 +1155,22 @@ export function formatSessionLine(session: SessionData): string {
 export interface LogTargetOptions {
   outputMode: OutputMode;
   hide?: boolean | undefined;
-  profileName?: string | undefined; // Auth profile being used (for http targets)
-  serverConfig?: ServerConfig | undefined; // Resolved transport config (for non-session targets)
 }
 
 /**
- * Log target prefix (only in human mode)
- * For sessions: [@name → server (auth)]
- * For direct connections: [target (auth)]
+ * Log session info prefix (only in human mode)
+ * Shows: [@name → server (auth)]
  */
 export async function logTarget(target: string, options: LogTargetOptions): Promise<void> {
   if (options.outputMode !== 'human' || options.hide) {
     return;
   }
 
-  // For session targets, show rich info
-  if (isValidSessionName(target)) {
-    const session = await getSession(target);
-    if (session) {
-      console.log(`[${formatSessionLine(session)}]\n`);
-    }
-    // Session not found - don't print anything, let the error handler show the message
-    return;
+  const session = await getSession(target);
+  if (session) {
+    console.log(`[${formatSessionLine(session)}]\n`);
   }
-
-  // For direct connections, use transportConfig if available
-  const tc = options.serverConfig;
-  if (tc?.command) {
-    // Stdio transport: show command + args
-    let targetStr = tc.command;
-    if (tc.args && tc.args.length > 0) {
-      targetStr += ' ' + tc.args.join(' ');
-    }
-    targetStr = truncateWithEllipsis(targetStr, 80);
-    console.log(`[→ ${targetStr}]`);
-    return;
-  }
-
-  // HTTP transport: show server URL with auth info
-  const serverStr = tc?.url || target;
-  if (options.profileName) {
-    console.log(
-      `[→ ${serverStr} ${chalk.dim('(OAuth: ') + chalk.magenta(options.profileName) + chalk.dim(')')}]\n`
-    );
-  } else {
-    console.log(`[→ ${serverStr}]\n`);
-  }
+  // Session not found - don't print anything, let the error handler show the message
 }
 
 /**

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -64,7 +64,6 @@ import type {
   ResourceTemplate,
   Prompt,
   ServerDetails,
-  ServerConfig,
   SessionData,
 } from '../../../src/lib/types.js';
 
@@ -1683,71 +1682,20 @@ describe('logTarget', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should not leak serverConfig.headers in output', async () => {
-    const serverConfig: ServerConfig = {
-      url: 'https://mcp.example.com',
-      headers: {
-        Authorization: 'Bearer super-secret-token-12345',
-        'X-Api-Key': 'secret-api-key-67890',
-      },
-    };
-
-    await logTarget('https://mcp.example.com', {
-      outputMode: 'human',
-      serverConfig,
-    });
-
-    // Get the output that was logged
-    const output = consoleSpy.mock.calls.map((call) => call.join(' ')).join('\n');
-
-    // Should NOT contain any header values
-    expect(output).not.toContain('super-secret-token-12345');
-    expect(output).not.toContain('secret-api-key-67890');
-    expect(output).not.toContain('Bearer');
-
-    // Should still show the server URL
-    expect(output).toContain('https://mcp.example.com');
-  });
-
-  it('should not leak headers for stdio transport', async () => {
-    const serverConfig: ServerConfig = {
-      command: 'npx',
-      args: ['-y', '@modelcontextprotocol/server-test'],
-      headers: {
-        Authorization: 'Bearer leaked-token',
-      },
-    };
-
-    await logTarget('test-server', {
-      outputMode: 'human',
-      serverConfig,
-    });
-
-    const output = consoleSpy.mock.calls.map((call) => call.join(' ')).join('\n');
-
-    // Should NOT contain header values
-    expect(output).not.toContain('leaked-token');
-    expect(output).not.toContain('Authorization');
-
-    // Should show command info
-    expect(output).toContain('npx');
-    expect(output).not.toContain('stdio');
-  });
-
   it('should not output anything in json mode', async () => {
-    const serverConfig: ServerConfig = {
-      url: 'https://mcp.example.com',
-      headers: {
-        Authorization: 'Bearer secret',
-      },
-    };
-
-    await logTarget('https://mcp.example.com', {
+    await logTarget('@test', {
       outputMode: 'json',
-      serverConfig,
     });
 
-    // Should not log anything in json mode
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not output anything when hide is true', async () => {
+    await logTarget('@test', {
+      outputMode: 'human',
+      hide: true,
+    });
+
     expect(consoleSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -1608,7 +1608,7 @@ describe('formatSessionLine', () => {
 
     expect(output).toContain('@test');
     expect(output).toContain('https://mcp.example.com');
-    expect(output).toContain('HTTP');
+    expect(output).not.toContain('HTTP');
     expect(output).toContain('OAuth');
     expect(output).toContain('default');
     expect(output).not.toContain('MCP:');
@@ -1628,7 +1628,7 @@ describe('formatSessionLine', () => {
 
     expect(output).toContain('@fs');
     expect(output).toContain('npx');
-    expect(output).toContain('stdio');
+    expect(output).not.toContain('stdio');
   });
 
   it('should include proxy info when configured', () => {
@@ -1731,7 +1731,7 @@ describe('logTarget', () => {
 
     // Should show command info
     expect(output).toContain('npx');
-    expect(output).toContain('stdio');
+    expect(output).not.toContain('stdio');
   });
 
   it('should not output anything in json mode', async () => {


### PR DESCRIPTION
## Summary
Simplify session info output by removing redundant transport type labels (`HTTP`/`stdio`), and clean up `logTarget` dead code now that every connection goes through a named session.

## Before / after

Before:
```
@fs → npx -y @modelcontextprotocol/server-filesystem /tmp (stdio) ● live
@apify → https://mcp.apify.com (HTTP, OAuth: default) ● live
@apify-bearer → https://mcp.apify.com (HTTP) ● connecting
```

After:
```
@fs → npx -y @modelcontextprotocol/server-filesystem /tmp ● live
@apify → https://mcp.apify.com (OAuth: default) ● live
@apify-bearer → https://mcp.apify.com ● connecting
```

## Changes
- **`formatSessionLine()`** — Dropped the `(stdio)` / `(HTTP)` labels; transport type is obvious from the target (URL vs. command). Only shows `(OAuth: <profile>)` when an OAuth profile is attached to an HTTP session. Fixed stale JSDoc that still mentioned `(transport, MCP: version)`.
- **`logTarget()`** — Removed the direct-connection branches (stdio and HTTP fallbacks). All MCP operations route through sessions now, so those code paths were unreachable. Removed unused `LogTargetOptions` fields (`profileName`, `serverConfig`) and unused imports (`ServerConfig`, `isValidSessionName`).
- **Tests** — Updated `formatSessionLine` assertions to match the new output. Replaced three `logTarget` tests that exercised removed direct-connection paths with two tests covering actual current behavior (JSON mode suppression and `hide` flag).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` (502 passing)
- [x] All CI checks green (Node 20/22/24, Bun E2E, Node E2E)

https://claude.ai/code/session_01Dsrm28xZKou39KWEKP1Hvv