### PR TITLE
Hide task-cancel hint for completed/failed tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `tools-call --task` now prints the task ID and recovery commands when interrupted with Ctrl+C, so you can fetch or cancel the server-side task later
+- `tasks-get` no longer suggests `tasks-cancel` when the task has already reached a terminal state (completed, failed, or cancelled)
 
 ### Removed
 

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -69,7 +69,7 @@ export async function getTask(
 
     if (options.outputMode === 'human') {
       console.log(formatTask(result));
-      console.log(formatTaskCommandsHint(target, taskId));
+      console.log(formatTaskCommandsHint(target, taskId, result.status));
     } else {
       console.log(formatOutput(result, 'json'));
     }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -303,7 +303,7 @@ export async function callTool(
 
       if (options.outputMode === 'human') {
         console.log(formatSuccess(`Task started: ${taskUpdate.taskId}`));
-        console.log(formatTaskCommandsHint(target, taskUpdate.taskId));
+        console.log(formatTaskCommandsHint(target, taskUpdate.taskId, taskUpdate.status));
       } else {
         console.log(formatOutput({ taskId: taskUpdate.taskId, status: taskUpdate.status }, 'json'));
       }
@@ -316,6 +316,7 @@ export async function callTool(
       let lastStatusMessage: string | undefined;
       let lastProgressMessage: string | undefined;
       let capturedTaskId: string | undefined;
+      let capturedTaskStatus: TaskUpdate['status'] | undefined;
 
       // Set up ESC key listener for detaching (TTY + human mode only, not in interactive shell)
       const escListener = setupEscListener(
@@ -329,7 +330,7 @@ export async function callTool(
         if (spinner) {
           spinner.info(`Detached. Task ${chalk.bold(`\`${taskId}\``)} continues in background`);
         }
-        console.log(formatTaskCommandsHint(target, taskId));
+        console.log(formatTaskCommandsHint(target, taskId, capturedTaskStatus ?? 'working'));
       };
 
       // Set up SIGINT handler to print task ID hint on Ctrl+C (human mode only)
@@ -363,6 +364,9 @@ export async function callTool(
       const onUpdate = (update: TaskUpdate): void => {
         if (update.taskId) {
           capturedTaskId = update.taskId;
+        }
+        if (update.status) {
+          capturedTaskStatus = update.status;
         }
         if (update.statusMessage) {
           lastStatusMessage = update.statusMessage;

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1087,14 +1087,23 @@ export function formatInfo(message: string): string {
   return chalk.cyan(`ℹ ${message}`);
 }
 
-export function formatTaskCommandsHint(target: string, taskId?: string): string {
+export function formatTaskCommandsHint(
+  target: string,
+  taskId?: string,
+  status?: Task['status']
+): string {
   const id = taskId ?? '<taskId>';
-  return [
+  const lines = [
     '\nAvailable commands:',
     `  mcpc ${target} tasks-get ${id}`,
     `  mcpc ${target} tasks-result ${id}`,
-    `  mcpc ${target} tasks-cancel ${id}`,
-  ].join('\n');
+  ];
+  // Only suggest cancel while the task is still active (or when status is unknown,
+  // e.g. the generic list hint where individual task statuses vary).
+  if (status === undefined || status === 'working' || status === 'input_required') {
+    lines.push(`  mcpc ${target} tasks-cancel ${id}`);
+  }
+  return lines.join('\n');
 }
 
 /**


### PR DESCRIPTION
## Summary
Updated the task commands hint to conditionally show the `tasks-cancel` command based on task status. The cancel command is now only suggested when a task is actively running or when its status is unknown.

## Key Changes
- Modified `formatTaskCommandsHint()` to accept an optional `status` parameter and conditionally include the cancel command only for active tasks (`working` or `input_required` status) or when status is undefined
- Updated all callers of `formatTaskCommandsHint()` to pass the task status:
  - `callTool()`: passes `taskUpdate.status` when task starts, and `capturedTaskStatus` when detaching
  - `getTask()`: passes `result.status` from the task query result
- Added `capturedTaskStatus` tracking in `callTool()` to preserve the last known task status when detaching with ESC key

## Implementation Details
- The status check uses `status === undefined || status === 'working' || status === 'input_required'` to determine when to show the cancel hint
- When status is undefined (e.g., in generic list hints where statuses vary), the cancel command is shown as a fallback
- When detaching without a captured status, defaults to `'working'` to maintain helpful hints for potentially active tasks

https://claude.ai/code/session_01UJmwwGfegLTJqaSXRBS3oV