### PR TITLE
Capture stdio server stderr for debugging connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sessions using a static bearer token (via `--header "Authorization: ..."`) no longer flip between `unauthorized` and `connecting` on every `mcpc` invocation — they stay `unauthorized` since retrying the same rejected token cannot succeed without `mcpc login` or reconnecting. OAuth-profile sessions still auto-retry because tokens may have been refreshed by another session
 - Server authentication errors now include the path to the bridge log file, so you can inspect it for more detail when investigating why a session was rejected
+- Stdio servers no longer fail silently: the bridge now captures the child's stderr, writes each line to `~/.mcpc/logs/bridge-<session>.log` with a `[server stderr]` prefix, and appends a tail of the most recent lines to `mcpc connect` errors. This makes it obvious when a stdio server crashes on startup due to e.g. missing TLS trust (`NODE_EXTRA_CA_CERTS`), missing proxy vars, or missing credentials, rather than "hanging silently" (#195)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1150,8 +1150,10 @@ For **stdio servers:**
 > **Note:** Stdio servers inherit only a minimal env whitelist from the shell
 > (`PATH`, `HOME`, `SHELL`, …). Other vars — `NODE_EXTRA_CA_CERTS`, `HTTPS_PROXY`,
 > `SSL_CERT_FILE`, etc. — must be forwarded explicitly via the `env` block using
-> `${VAR_NAME}`. If `mcpc connect` hangs silently on a stdio server, re-run with
-> `--verbose` to see its stderr.
+> `${VAR_NAME}`. Anything the server writes to stderr is captured to
+> `~/.mcpc/logs/bridge-<session>.log` with a `[server stderr]` prefix, and the
+> tail is appended to the error message if `mcpc connect` fails, so you can see
+> why a stdio server failed to start.
 
 **Using servers from config file:**
 

--- a/README.md
+++ b/README.md
@@ -1147,39 +1147,11 @@ For **stdio servers:**
 - `args` (optional) - Array of command arguments
 - `env` (optional) - Environment variables for the process
 
-> **Note: stdio servers inherit a minimal environment.**
-> For security reasons (see the
-> [MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/stdio.ts)),
-> spawned stdio servers receive only a small whitelist of vars from the shell:
-> `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER` on Unix, and the equivalent
-> user/system vars on Windows. Everything else — proxy settings, TLS CA bundles,
-> language-specific options — must be forwarded explicitly via the config `env`
-> block using `${VAR_NAME}` substitution.
->
-> This matters most in TLS-intercepting proxy environments, where the child
-> process needs `NODE_EXTRA_CA_CERTS` (Node), `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`
-> (Python) or `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` to trust the proxy's CA
-> and reach the upstream API:
->
-> ```json
-> {
->   "mcpServers": {
->     "apify": {
->       "command": "node",
->       "args": ["/path/to/server.js"],
->       "env": {
->         "APIFY_TOKEN": "${APIFY_TOKEN}",
->         "NODE_EXTRA_CA_CERTS": "${NODE_EXTRA_CA_CERTS}",
->         "HTTPS_PROXY": "${HTTPS_PROXY}"
->       }
->     }
->   }
-> }
-> ```
->
-> If `mcpc connect <config>:<entry>` hangs with no output, re-run it with
-> `--verbose` to surface the child server's stderr — that almost always reveals
-> the real error (missing CA trust, missing credentials, unresolved dependency, …).
+> **Note:** Stdio servers inherit only a minimal env whitelist from the shell
+> (`PATH`, `HOME`, `SHELL`, …). Other vars — `NODE_EXTRA_CA_CERTS`, `HTTPS_PROXY`,
+> `SSL_CERT_FILE`, etc. — must be forwarded explicitly via the `env` block using
+> `${VAR_NAME}`. If `mcpc connect` hangs silently on a stdio server, re-run with
+> `--verbose` to see its stderr.
 
 **Using servers from config file:**
 

--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,40 @@ For **stdio servers:**
 - `args` (optional) - Array of command arguments
 - `env` (optional) - Environment variables for the process
 
+> **Note: stdio servers inherit a minimal environment.**
+> For security reasons (see the
+> [MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/client/stdio.ts)),
+> spawned stdio servers receive only a small whitelist of vars from the shell:
+> `HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER` on Unix, and the equivalent
+> user/system vars on Windows. Everything else — proxy settings, TLS CA bundles,
+> language-specific options — must be forwarded explicitly via the config `env`
+> block using `${VAR_NAME}` substitution.
+>
+> This matters most in TLS-intercepting proxy environments, where the child
+> process needs `NODE_EXTRA_CA_CERTS` (Node), `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`
+> (Python) or `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` to trust the proxy's CA
+> and reach the upstream API:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "apify": {
+>       "command": "node",
+>       "args": ["/path/to/server.js"],
+>       "env": {
+>         "APIFY_TOKEN": "${APIFY_TOKEN}",
+>         "NODE_EXTRA_CA_CERTS": "${NODE_EXTRA_CA_CERTS}",
+>         "HTTPS_PROXY": "${HTTPS_PROXY}"
+>       }
+>     }
+>   }
+> }
+> ```
+>
+> If `mcpc connect <config>:<entry>` hangs with no output, re-run it with
+> `--verbose` to surface the child server's stderr — that almost always reveals
+> the real error (missing CA trust, missing credentials, unresolved dependency, …).
+
 **Using servers from config file:**
 
 Reference servers by their name using the `file:entry` syntax:

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -499,13 +499,20 @@ class BridgeProcess {
    * with a prefix, and keep a bounded tail for surfacing in connect failures.
    */
   private recordServerStderr(line: string): void {
-    logger.info(`[server stderr] ${line}`);
+    // Cap per-line length so a single huge line (stack trace, etc.) can't push
+    // every other line out of the bounded tail or get itself fully evicted.
+    const trimmed =
+      line.length > BridgeProcess.STDERR_TAIL_MAX_CHARS
+        ? line.slice(0, BridgeProcess.STDERR_TAIL_MAX_CHARS) + '…'
+        : line;
 
-    this.stderrTail.push(line);
-    this.stderrTailChars += line.length + 1;
+    logger.info(`[server stderr] ${trimmed}`);
+
+    this.stderrTail.push(trimmed);
+    this.stderrTailChars += trimmed.length + 1;
     while (
       this.stderrTail.length > BridgeProcess.STDERR_TAIL_MAX_LINES ||
-      this.stderrTailChars > BridgeProcess.STDERR_TAIL_MAX_CHARS
+      (this.stderrTail.length > 1 && this.stderrTailChars > BridgeProcess.STDERR_TAIL_MAX_CHARS)
     ) {
       const removed = this.stderrTail.shift();
       if (removed === undefined) break;

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -123,6 +123,14 @@ class BridgeProcess {
   private mcpClientReadyResolver!: () => void;
   private mcpClientReadyRejecter!: (error: Error) => void;
 
+  // Bounded tail of stderr lines emitted by a stdio server, surfaced in the
+  // connect-failure error so the CLI can show users why startup failed
+  // (e.g. TLS errors when NODE_EXTRA_CA_CERTS is not forwarded — see #195).
+  private stderrTail: string[] = [];
+  private stderrTailChars = 0;
+  private static readonly STDERR_TAIL_MAX_LINES = 50;
+  private static readonly STDERR_TAIL_MAX_CHARS = 8_000;
+
   constructor(options: BridgeOptions) {
     this.options = options;
     // Each bridge instance gets a unique socket path based on its PID, so that
@@ -429,6 +437,12 @@ class BridgeProcess {
         if (isAuthenticationError(errorMsg) && !(error instanceof AuthError)) {
           classifiedError = new AuthError(errorMsg);
         }
+        // Append recent stdio server stderr so the CLI can show the user why
+        // startup failed (common case: missing NODE_EXTRA_CA_CERTS etc.).
+        if (this.stderrTail.length > 0) {
+          const tail = this.stderrTail.map((l) => `  ${l}`).join('\n');
+          classifiedError.message = `${classifiedError.message}\n\nRecent server stderr:\n${tail}`;
+        }
         this.mcpClientReadyRejecter(classifiedError);
 
         // If the error was due to session ID rejection or auth failure, mark session status
@@ -477,6 +491,25 @@ class BridgeProcess {
       logger.error('Failed to start bridge:', error);
       await this.cleanup();
       throw error;
+    }
+  }
+
+  /**
+   * Record a stderr line from a stdio server: write it to the bridge log file
+   * with a prefix, and keep a bounded tail for surfacing in connect failures.
+   */
+  private recordServerStderr(line: string): void {
+    logger.info(`[server stderr] ${line}`);
+
+    this.stderrTail.push(line);
+    this.stderrTailChars += line.length + 1;
+    while (
+      this.stderrTail.length > BridgeProcess.STDERR_TAIL_MAX_LINES ||
+      this.stderrTailChars > BridgeProcess.STDERR_TAIL_MAX_CHARS
+    ) {
+      const removed = this.stderrTail.shift();
+      if (removed === undefined) break;
+      this.stderrTailChars -= removed.length + 1;
     }
   }
 
@@ -593,6 +626,8 @@ class BridgeProcess {
       ...(this.options.mcpSessionId && { mcpSessionId: this.options.mcpSessionId }),
       // Pass x402 fetch middleware (HTTP transport only)
       ...(customFetch && { customFetch }),
+      // Route stdio server stderr into the bridge log + tail buffer
+      onStderrLine: (line: string) => this.recordServerStderr(line),
       listChanged: {
         tools: {
           // We handle refresh ourselves to fetch ALL pages (SDK only fetches the first page).

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -456,14 +456,12 @@ ${chalk.bold('Session name:')}
   names) is reused, and restarted if not live. Cannot be set when connecting
   all servers from a config file.
 
-${chalk.bold('Security:')}
-  Stdio config entries execute the configured command locally on connect,
-  even if the MCP handshake later fails. Only connect to configs you trust.
-
-${chalk.bold('Stdio environment:')}
-  Stdio servers inherit a minimal env whitelist; forward extras (e.g.
-  NODE_EXTRA_CA_CERTS, HTTPS_PROXY) via the "env" block. Server stderr
-  is logged to ~/.mcpc/logs/bridge-<session>.log.
+${chalk.bold('Stdio servers:')}
+  Config entries execute the configured command locally on connect, even if
+  the MCP handshake later fails — only connect to configs you trust. Stdio
+  servers inherit a minimal env whitelist; forward extras (e.g.
+  NODE_EXTRA_CA_CERTS, HTTPS_PROXY) via the "env" block. Server stderr is
+  logged to ~/.mcpc/logs/bridge-<session>.log.
 ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` metadata', '`{ protocolVersion, capabilities, serverInfo, instructions?, toolNames?, _mcpc }`', `${SCHEMA_BASE}#initializeresult`)}`
     )
     .action(async (server, sessionName, opts, command) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -461,11 +461,9 @@ ${chalk.bold('Security:')}
   even if the MCP handshake later fails. Only connect to configs you trust.
 
 ${chalk.bold('Stdio environment:')}
-  Stdio servers inherit only a minimal env whitelist (PATH, HOME, SHELL, …).
-  Forward other vars (NODE_EXTRA_CA_CERTS, HTTPS_PROXY, SSL_CERT_FILE, …)
-  via the config "env" block using \${VAR_NAME}. Server stderr is captured
-  to ~/.mcpc/logs/bridge-<session>.log, and the tail is appended to connect
-  errors so you can see why a stdio server failed to start.
+  Stdio servers inherit a minimal env whitelist; forward extras (e.g.
+  NODE_EXTRA_CA_CERTS, HTTPS_PROXY) via the "env" block. Server stderr
+  is logged to ~/.mcpc/logs/bridge-<session>.log.
 ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` metadata', '`{ protocolVersion, capabilities, serverInfo, instructions?, toolNames?, _mcpc }`', `${SCHEMA_BASE}#initializeresult`)}`
     )
     .action(async (server, sessionName, opts, command) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -459,6 +459,12 @@ ${chalk.bold('Session name:')}
 ${chalk.bold('Security:')}
   Stdio config entries execute the configured command locally on connect,
   even if the MCP handshake later fails. Only connect to configs you trust.
+
+${chalk.bold('Stdio environment:')}
+  Stdio servers inherit only a minimal env whitelist (PATH, HOME, SHELL, …).
+  Forward other vars (NODE_EXTRA_CA_CERTS, HTTPS_PROXY, SSL_CERT_FILE, …)
+  via the config "env" block using \${VAR_NAME}. If a stdio connect hangs
+  with no output, re-run with --verbose to surface the server's stderr.
 ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` metadata', '`{ protocolVersion, capabilities, serverInfo, instructions?, toolNames?, _mcpc }`', `${SCHEMA_BASE}#initializeresult`)}`
     )
     .action(async (server, sessionName, opts, command) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -463,8 +463,9 @@ ${chalk.bold('Security:')}
 ${chalk.bold('Stdio environment:')}
   Stdio servers inherit only a minimal env whitelist (PATH, HOME, SHELL, …).
   Forward other vars (NODE_EXTRA_CA_CERTS, HTTPS_PROXY, SSL_CERT_FILE, …)
-  via the config "env" block using \${VAR_NAME}. If a stdio connect hangs
-  with no output, re-run with --verbose to surface the server's stderr.
+  via the config "env" block using \${VAR_NAME}. Server stderr is captured
+  to ~/.mcpc/logs/bridge-<session>.log, and the tail is appended to connect
+  errors so you can see why a stdio server failed to start.
 ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` metadata', '`{ protocolVersion, capabilities, serverInfo, instructions?, toolNames?, _mcpc }`', `${SCHEMA_BASE}#initializeresult`)}`
     )
     .action(async (server, sessionName, opts, command) => {

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -59,6 +59,12 @@ export interface CreateMcpClientOptions {
   customFetch?: FetchLike;
 
   /**
+   * Callback for lines written to stderr by the child (stdio transport only).
+   * Ignored for HTTP transports.
+   */
+  onStderrLine?: (line: string) => void;
+
+  /**
    * Whether to automatically connect after creation
    * @default true
    */
@@ -132,6 +138,7 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
       authProvider?: OAuthClientProvider;
       mcpSessionId?: string;
       customFetch?: FetchLike;
+      onStderrLine?: (line: string) => void;
     } = {};
     if (options.authProvider) {
       transportOptions.authProvider = options.authProvider;
@@ -141,6 +148,9 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     }
     if (options.customFetch) {
       transportOptions.customFetch = options.customFetch;
+    }
+    if (options.onStderrLine) {
+      transportOptions.onStderrLine = options.onStderrLine;
     }
     const transport = createTransportFromConfig(options.serverConfig, transportOptions);
     await client.connect(transport);

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -40,6 +40,8 @@ import { createLogger, getVerbose } from '../lib/logger.js';
 import type { ServerConfig } from '../lib/types.js';
 import { ClientError } from '../lib/errors.js';
 import { proxyFetch } from '../lib/proxy.js';
+import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
 
 /**
  * Options for createStdioTransport
@@ -80,31 +82,17 @@ export function createStdioTransport(
     // With stderr: 'pipe', the SDK exposes a PassThrough stream on
     // `transport.stderr` from construction time onwards, so we can attach the
     // reader before `start()` is called without losing any output.
-    const stream = transport.stderr;
+    // SDK types stderr as the abstract Stream class; the runtime value is
+    // always a PassThrough (Readable) when stderr === 'pipe'.
+    const stream = transport.stderr as Readable | null;
     if (stream) {
-      let buffer = '';
-      stream.on('data', (chunk: Buffer | string) => {
-        buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-        let newlineIndex: number;
-        while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
-          const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
-          buffer = buffer.slice(newlineIndex + 1);
-          if (line.length > 0) {
-            try {
-              handler(line);
-            } catch (err) {
-              logger.debug('onStderrLine handler threw:', err);
-            }
-          }
-        }
-      });
-      stream.on('end', () => {
-        if (buffer.length > 0) {
-          try {
-            handler(buffer.replace(/\r$/, ''));
-          } catch (err) {
-            logger.debug('onStderrLine handler threw:', err);
-          }
+      const rl = createInterface({ input: stream, crlfDelay: Infinity });
+      rl.on('line', (line) => {
+        if (line.length === 0) return;
+        try {
+          handler(line);
+        } catch (err) {
+          logger.debug('onStderrLine handler threw:', err);
         }
       });
     }

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -42,20 +42,75 @@ import { ClientError } from '../lib/errors.js';
 import { proxyFetch } from '../lib/proxy.js';
 
 /**
+ * Options for createStdioTransport
+ */
+export interface CreateStdioTransportOptions {
+  /**
+   * Callback invoked for each newline-delimited line written by the child
+   * server to stderr. When provided, stderr is piped and consumed; when not,
+   * it is inherited in verbose mode and discarded otherwise.
+   */
+  onStderrLine?: (line: string) => void;
+}
+
+/**
  * Create a stdio transport for a local MCP server
  */
-export function createStdioTransport(config: StdioServerParameters): Transport {
+export function createStdioTransport(
+  config: StdioServerParameters,
+  options: CreateStdioTransportOptions = {}
+): Transport {
   const logger = createLogger('StdioTransport');
   logger.debug('Creating stdio transport', { command: config.command, args: config.args });
 
-  // Suppress server stderr unless in verbose mode
-  // Server stderr typically contains startup messages that clutter output
+  // Pipe stderr when a handler is provided so the caller (bridge) can log it
+  // to the session log and surface it on connect failures. Otherwise fall back
+  // to inheriting in verbose mode or dropping it — stdio servers often print
+  // noisy startup banners that would clutter normal CLI output.
+  const shouldPipe = !!options.onStderrLine;
   const params: StdioServerParameters = {
     ...config,
-    stderr: getVerbose() ? 'inherit' : 'ignore',
+    stderr: shouldPipe ? 'pipe' : getVerbose() ? 'inherit' : 'ignore',
   };
 
-  return new StdioClientTransport(params);
+  const transport = new StdioClientTransport(params);
+
+  if (options.onStderrLine) {
+    const handler = options.onStderrLine;
+    // With stderr: 'pipe', the SDK exposes a PassThrough stream on
+    // `transport.stderr` from construction time onwards, so we can attach the
+    // reader before `start()` is called without losing any output.
+    const stream = transport.stderr;
+    if (stream) {
+      let buffer = '';
+      stream.on('data', (chunk: Buffer | string) => {
+        buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+        let newlineIndex: number;
+        while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
+          buffer = buffer.slice(newlineIndex + 1);
+          if (line.length > 0) {
+            try {
+              handler(line);
+            } catch (err) {
+              logger.debug('onStderrLine handler threw:', err);
+            }
+          }
+        }
+      });
+      stream.on('end', () => {
+        if (buffer.length > 0) {
+          try {
+            handler(buffer.replace(/\r$/, ''));
+          } catch (err) {
+            logger.debug('onStderrLine handler threw:', err);
+          }
+        }
+      });
+    }
+  }
+
+  return transport;
 }
 
 /**
@@ -133,6 +188,12 @@ export interface CreateTransportOptions {
    * Used by x402 middleware to intercept and modify requests
    */
   customFetch?: FetchLike;
+
+  /**
+   * Callback for lines written to stderr by the child (stdio transport only).
+   * Ignored for HTTP transports.
+   */
+  onStderrLine?: (line: string) => void;
 }
 
 /**
@@ -155,7 +216,9 @@ export function createTransportFromConfig(
       stdioConfig.env = config.env;
     }
 
-    return createStdioTransport(stdioConfig);
+    return createStdioTransport(stdioConfig, {
+      ...(options.onStderrLine && { onStderrLine: options.onStderrLine }),
+    });
   }
 
   // HTTP transport


### PR DESCRIPTION
## Summary

Makes stdio MCP server failures debuggable instead of silent (fixes #195).

Previously, stderr from a stdio server was either inherited (only in `--verbose`, and even then dropped to `/dev/null` since the bridge is spawned with `stdio: 'ignore'`) or discarded. A child crashing because `NODE_EXTRA_CA_CERTS` wasn't forwarded — the scenario in #195 — looked like a silent hang.

## Changes

- **Transport** (`src/core/transports.ts`, `src/core/factory.ts`): `createStdioTransport` accepts an `onStderrLine(line)` callback. When set, stderr is piped and split with `readline.createInterface` (handles `\r\n` / partial lines). Plumbed through `CreateTransportOptions` and `CreateMcpClientOptions`.
- **Bridge** (`src/bridge/index.ts`): every line is logged to `~/.mcpc/logs/bridge-<session>.log` with a `[server stderr]` prefix and kept in a bounded tail (50 lines / 8 KB, lines trimmed to 8 KB on push so a single giant stack trace doesn't evict itself). On connect failure, the tail is appended to the error message sent back to the CLI.
- **Docs** (`src/cli/index.ts`, `README.md`, `CHANGELOG.md`): `mcpc connect --help` and the README now document the SDK's env whitelist and where stderr is captured. Earlier `--verbose` pointer was removed (it didn't actually work for stdio via the bridge).

## User-visible behavior

```
$ mcpc connect my-stdio-server.json:apify @apify
[@apify → node my-stdio-server.js]

⚠ Session @apify created but server is not responding: TLS/SSL error. Check the server's certificate.
  Original error: Failed to connect to MCP server: MCP error -32000: Connection closed

Recent server stderr:
  cannot verify TLS: self-signed certificate in chain
  tried https://api.upstream.example.com
  exiting
For details, check logs at ~/.mcpc/logs/bridge-@apify.log
```

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` (532/532)
- [x] Smoke-tested with a fake stdio server that writes to stderr and exits — verified tail is captured in both the log file and the CLI error output
- [x] Smoke-tested with a 20 KB-long line — verified it's trimmed to 8 KB with `…` indicator instead of being evicted

https://claude.ai/code/session_01PsfRHoKCVFnmxGqQfGEB1o