### PR TITLE
Gate releases on MCP spec conformance checks

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,6 +17,17 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      scenario:
+        description: "Scenario name to run. Leave blank to run the full matrix of supported scenarios."
+        required: false
+        type: string
+      verbose:
+        description: "Enable verbose output from the conformance framework"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   conformance:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,22 @@ jobs:
     if: ${{ !inputs.skip-windows-e2e }}
     uses: ./.github/workflows/e2e-windows.yml
 
+  conformance:
+    # Gate releases on MCP spec conformance so we never publish a version
+    # that regresses against the reference conformance suite.
+    uses: ./.github/workflows/conformance.yml
+
   release:
     name: Publish ${{ inputs.type }}
     runs-on: ubuntu-latest
-    needs: [e2e-windows]
+    needs: [e2e-windows, conformance]
     # Release must be from main; pre-release can be from any branch.
     # Allow the e2e-windows dependency to be either successful or skipped
-    # (when the user opts out via skip-windows-e2e).
+    # (when the user opts out via skip-windows-e2e). Conformance must pass.
     if: |
       always() &&
       (needs.e2e-windows.result == 'success' || needs.e2e-windows.result == 'skipped') &&
+      needs.conformance.result == 'success' &&
       (inputs.type == 'pre-release' || github.ref == 'refs/heads/main')
 
     steps:


### PR DESCRIPTION
## Summary
This change adds MCP spec conformance validation as a required gate for releases, ensuring that published versions never regress against the reference conformance suite.

## Key Changes
- **conformance.yml**: Added `workflow_call` trigger to allow the conformance workflow to be called from other workflows (e.g., release.yml)
  - Accepts optional `scenario` input to run specific scenarios or the full matrix
  - Accepts optional `verbose` input for detailed output
  
- **release.yml**: Integrated conformance checks into the release pipeline
  - Added new `conformance` job that calls the conformance workflow
  - Updated `release` job to depend on both `e2e-windows` and `conformance` jobs
  - Modified the release condition to require `conformance.result == 'success'`
  - Updated comments to reflect the new conformance requirement

## Implementation Details
The conformance workflow is now reusable via `workflow_call`, allowing it to be invoked as part of the release workflow. The release will only proceed if conformance tests pass, preventing any regressions in MCP spec compliance from being published.

https://claude.ai/code/session_018TUXYPy9gioTLeK2XLmMi2