### PR TITLE
Skip stdio config entries by default in bulk connect, add `--stdio` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - OAuth callback ports for the hosted CIMD changed from the contiguous range 13316–13325 to 6 non-contiguous ports (13316, 13163, 31316, 31613, 16133, 16313) so one unrelated process is less likely to claim all of them. `localhost` variants dropped from the CIMD's `redirect_uris` in favor of `127.0.0.1` only (per RFC 8252 §8.3, which recommends the IP literal to avoid DNS resolution ambiguity).
+- Stdio (command-based) config entries are now skipped by default when connecting from a config file (`mcpc connect <file>`). Pass `--stdio` to include them. Single-entry connects (`mcpc connect file:entry @session`) are not affected.
 - `restart` success message now notes that previous session state (resource subscriptions, pending notifications, async tasks) was lost, since explicit restart always creates a fresh MCP session
 - `tasks-list` now shows a hint on how to start a new task (`mcpc @session tools-call <name> [args] --task`) when there are no active tasks
 - `mcpc help <command>` now shows a "Did you mean?" suggestion when the command is unknown (e.g., `mcpc help tasks-gfet` → suggests `tasks-get`)

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -55,7 +55,7 @@ import { getWallet } from '../../lib/wallets.js';
 import chalk from 'chalk';
 import { createLogger } from '../../lib/logger.js';
 import { parseProxyArg } from '../parser.js';
-import { loadConfig, listServers } from '../../lib/config.js';
+import { loadConfig, listServers, isStdioEntry } from '../../lib/config.js';
 
 const logger = createLogger('sessions');
 
@@ -911,15 +911,53 @@ export async function connectAllFromConfig(
     noProfile?: boolean;
     proxy?: string;
     proxyBearerToken?: string;
+    stdio?: boolean;
     x402?: boolean;
     insecure?: boolean;
   }
 ): Promise<void> {
   const config = loadConfig(configFile);
-  const serverNames = listServers(config);
+  const allNames = listServers(config);
+
+  if (allNames.length === 0) {
+    throw new ClientError(`No servers found in config file: ${configFile}`);
+  }
+
+  // Filter out stdio entries unless --stdio is passed. Stdio entries execute
+  // arbitrary local commands via child_process.spawn(), so bulk-connect
+  // operations default to skipping them to mitigate supply-chain risk from
+  // malicious config files.
+  const stdioSkipped: string[] = [];
+  const serverNames = allNames.filter((name) => {
+    if (!options.stdio && isStdioEntry(config, name)) {
+      stdioSkipped.push(name);
+      return false;
+    }
+    return true;
+  });
 
   if (serverNames.length === 0) {
-    throw new ClientError(`No servers found in config file: ${configFile}`);
+    if (options.outputMode === 'json') {
+      console.log(
+        formatOutput(
+          {
+            configFile,
+            results: [],
+            skipped: stdioSkipped.map((entry) => ({
+              entry,
+              sessionName: generateSessionName({ type: 'config', file: configFile, entry }),
+              reason: 'stdio',
+            })),
+          },
+          'json'
+        )
+      );
+      return;
+    }
+    throw new ClientError(
+      `All ${allNames.length} server${allNames.length === 1 ? '' : 's'} in ${configFile} use stdio transport.\n` +
+        `Pass --stdio to include them: mcpc connect ${configFile} --stdio`
+    );
   }
 
   if (options.outputMode === 'human') {
@@ -928,6 +966,14 @@ export async function connectAllFromConfig(
         `Connecting ${serverNames.length} server${serverNames.length === 1 ? '' : 's'} from ${configFile}...`
       )
     );
+    if (stdioSkipped.length > 0) {
+      console.log(
+        chalk.dim(
+          `  skipping ${stdioSkipped.length} stdio server${stdioSkipped.length === 1 ? '' : 's'} ` +
+            `(${stdioSkipped.join(', ')}), pass --stdio to include`
+        )
+      );
+    }
   }
 
   // Prepare entries with deterministic session names derived from entry names.
@@ -1019,6 +1065,13 @@ export async function connectAllFromConfig(
             status: r.status,
             ...(r.error && { error: r.error }),
           })),
+          ...(stdioSkipped.length > 0 && {
+            skipped: stdioSkipped.map((entry) => ({
+              entry,
+              sessionName: generateSessionName({ type: 'config', file: configFile, entry }),
+              reason: 'stdio',
+            })),
+          }),
         },
         'json'
       )

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -441,6 +441,7 @@ Full docs: ${docsUrl}`
     .option('--no-profile', 'Skip OAuth profile (connect anonymously)')
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
+    .option('--stdio', 'Include stdio (command-based) servers when connecting from config files')
     .option('--x402', 'Enable x402 auto-payment using the configured wallet')
     .addHelpText(
       'after',
@@ -462,6 +463,10 @@ ${chalk.bold('Stdio servers:')}
   servers inherit a minimal env whitelist; forward extras (e.g.
   NODE_EXTRA_CA_CERTS, HTTPS_PROXY) via the "env" block. Server stderr is
   logged to ~/.mcpc/logs/bridge-<session>.log.
+
+  When connecting from a config file (\`mcpc connect <config-file>\`), stdio
+  entries are skipped by default — pass --stdio to include them. Single-entry
+  connects (\`mcpc connect file:entry\`) are not affected.
 ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` metadata', '`{ protocolVersion, capabilities, serverInfo, instructions?, toolNames?, _mcpc }`', `${SCHEMA_BASE}#initializeresult`)}`
     )
     .action(async (server, sessionName, opts, command) => {
@@ -500,6 +505,7 @@ ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` meta
           ...(headers && { headers }),
           ...(opts.proxy && { proxy: opts.proxy as string }),
           ...(opts.proxyBearerToken && { proxyBearerToken: opts.proxyBearerToken as string }),
+          ...(opts.stdio && { stdio: true }),
           ...(opts.x402 && { x402: opts.x402 as boolean }),
           ...(globalOpts.insecure && { insecure: true }),
         });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -464,9 +464,9 @@ ${chalk.bold('Stdio servers:')}
   NODE_EXTRA_CA_CERTS, HTTPS_PROXY) via the "env" block. Server stderr is
   logged to ~/.mcpc/logs/bridge-<session>.log.
 
-  When connecting from a config file (\`mcpc connect <config-file>\`), stdio
-  entries are skipped by default — pass --stdio to include them. Single-entry
-  connects (\`mcpc connect file:entry\`) are not affected.
+  Bulk connects (\`mcpc connect <config-file>\`) skip stdio entries by
+  default; pass --stdio to include them. Single-entry connects are
+  unaffected.
 ${jsonHelp('`InitializeResult` object extended with `toolNames` and `_mcpc` metadata', '`{ protocolVersion, capabilities, serverInfo, instructions?, toolNames?, _mcpc }`', `${SCHEMA_BASE}#initializeresult`)}`
     )
     .action(async (server, sessionName, opts, command) => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -228,3 +228,11 @@ export function validateServerConfig(config: ServerConfig): boolean {
 
   return true;
 }
+
+/**
+ * Check whether a named entry in an MCP config uses the stdio transport
+ * (i.e. has a `command` field rather than a `url`).
+ */
+export function isStdioEntry(config: McpConfig, entryName: string): boolean {
+  return config.mcpServers[entryName]?.command !== undefined;
+}

--- a/test/unit/lib/config.test.ts
+++ b/test/unit/lib/config.test.ts
@@ -9,6 +9,7 @@ import {
   getServerConfig,
   validateServerConfig,
   listServers,
+  isStdioEntry,
 } from '../../../src/lib/config.js';
 import { ClientError } from '../../../src/lib/errors.js';
 
@@ -167,6 +168,46 @@ describe('validateServerConfig', () => {
     const config = { command: '' };
     expect(() => validateServerConfig(config)).toThrow(ClientError);
     expect(() => validateServerConfig(config)).toThrow('must be a non-empty string');
+  });
+});
+
+describe('isStdioEntry', () => {
+  it('returns true for entries with a command field', () => {
+    const config = {
+      mcpServers: {
+        local: { command: 'node', args: ['server.js'] },
+      },
+    };
+    expect(isStdioEntry(config, 'local')).toBe(true);
+  });
+
+  it('returns false for entries with a url field', () => {
+    const config = {
+      mcpServers: {
+        remote: { url: 'https://example.com' },
+      },
+    };
+    expect(isStdioEntry(config, 'remote')).toBe(false);
+  });
+
+  it('returns false for non-existent entries', () => {
+    const config = {
+      mcpServers: {
+        remote: { url: 'https://example.com' },
+      },
+    };
+    expect(isStdioEntry(config, 'missing')).toBe(false);
+  });
+
+  it('correctly distinguishes entries in a mixed config', () => {
+    const config = {
+      mcpServers: {
+        http: { url: 'https://example.com' },
+        stdio: { command: 'npx', args: ['-y', 'mcp-server'] },
+      },
+    };
+    expect(isStdioEntry(config, 'http')).toBe(false);
+    expect(isStdioEntry(config, 'stdio')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Isolated from #165 to make review and testing easier. This PR only contains the `--stdio` safety gate for bulk `mcpc connect <config-file>` operations. The auto-discovery feature (`mcpc connect` with no args) remains in #165 and can be merged separately.

## Motivation

Stdio entries in MCP config files execute arbitrary local commands via `child_process.spawn()`. When connecting all servers from a config file at once, this is a supply-chain risk — a malicious or compromised config could silently execute code on connect, even if the MCP handshake later fails.

This PR defaults bulk connects to HTTP-only entries and requires an explicit `--stdio` opt-in to execute stdio entries.

## Behavior

- **`mcpc connect <config-file>`** — stdio entries are skipped by default with a `chalk.dim` message listing what was skipped and how to include them. Pass `--stdio` to include stdio entries.
- **`mcpc connect file:entry`** — single-entry connects are **not affected** (explicit opt-in per entry).
- **All-stdio config** — if every entry in the config is stdio and `--stdio` is not passed, a clear error with remediation is shown.
- **JSON output** — skipped entries appear under `skipped` with `reason: "stdio"`.

## Changes

### `src/lib/config.ts`

- Adds `isStdioEntry(config, entryName)` helper that returns true when the entry has a `command` field.

### `src/cli/commands/sessions.ts`

- `connectAllFromConfig()` partitions server names into "to connect" and "stdio skipped" unless `options.stdio` is true, prints a dim skip summary in human mode, emits a `skipped` array with `reason: "stdio"` in JSON mode, and throws a clear error (with `--stdio` remediation) when every entry is stdio.

### `src/cli/index.ts`

- Adds `--stdio` option to `connect`.
- Extends the `Stdio servers` help section to document the new default-skip behavior and the `--stdio` opt-in.
- Forwards `opts.stdio` to `connectAllFromConfig()`.

### `test/unit/lib/config.test.ts`

- Unit tests for `isStdioEntry()` covering command-only, url-only, missing, and mixed configs.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run test:unit` passes (559/559)
- [ ] Manual check: `mcpc connect <config-with-mixed-entries>` skips stdio by default
- [ ] Manual check: `mcpc connect <config-with-mixed-entries> --stdio` connects all
- [ ] Manual check: `mcpc connect <stdio-only-config>` errors with remediation
- [ ] Manual check: `mcpc connect file:entry` still works for stdio entries (no `--stdio` needed)
- [ ] Manual check: `--json` output includes `skipped` entries with `reason: "stdio"`

https://claude.ai/code/session_0138fCGaEqxPbT7y2hWFAAC1

---
_Generated by [Claude Code](https://claude.ai/code/session_0138fCGaEqxPbT7y2hWFAAC1)_