### PR TITLE
Document --json flag for mcpc command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ MCP session commands (after connecting):
   <@session> ping
 
 Run "mcpc" without arguments to show active sessions and OAuth profiles.
+Run "mcpc --json" to get the same data as `{ sessions: [...], profiles: [...] }`.
 ```
 
 ### General actions

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -427,6 +427,7 @@ ${chalk.bold('MCP session commands (after connecting):')}
   <@session> ${chalk.cyan('ping')}
 
 Run "mcpc" without arguments to show active sessions and OAuth profiles.
+Run "mcpc --json" to get the same data as \`{ sessions: [...], profiles: [...] }\`.
 
 Full docs: ${docsUrl}`
   );


### PR DESCRIPTION
## Summary
Updated the CLI help text to document the `--json` flag for the `mcpc` command, which outputs session and profile data in JSON format.

## Changes
- Added documentation in the help text explaining that running `mcpc --json` returns data as `{ sessions: [...], profiles: [...] }`
- This clarifies an existing feature for users who want to programmatically access session and profile information

## Details
The change is a documentation-only update to the CLI help output. It informs users that the `--json` flag is available as an alternative to the default human-readable output when running `mcpc` without arguments.

https://claude.ai/code/session_0196X4o7ojVFiMoBNUDK2nsM