### PR TITLE
Add AI agent discoverability requirement to design principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ mcpc @fs tools-list
 - Avoid unnecessary interaction loops, provide sufficient context, yet be concise (save tokens)
 - One clear way to do things (orthogonal commands, no surprises)
 - Do not ask for user input (except `shell` and `login`, no unexpected OAuth flows)
+- AI agents must be able to use mcpc without any external agent skills, prompts, or documentation: `--help` output and error messages must provide all the context an agent needs to discover commands, understand arguments, and recover from mistakes
 - Be forgiving, always help users make progress (great errors + guidance)
 - Be consistent with the [MCP specification](https://modelcontextprotocol.io/specification/latest), with `--json` strictly
 - Minimal and portable (few deps, cross-platform)


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md design principles to explicitly require that AI agents must be able to use mcpc independently, with all necessary context provided through `--help` output and error messages.

## Changes
- Added a new design principle stating that AI agents must be able to use mcpc without external agent skills, prompts, or documentation
- Clarified that `--help` output and error messages must provide sufficient context for agents to discover commands, understand arguments, and recover from mistakes

## Rationale
This principle ensures that mcpc is designed with AI agent usability as a first-class concern, making the tool accessible to autonomous agents without requiring additional documentation or custom prompts. This aligns with the existing principle of avoiding unexpected user interactions and promotes self-service discoverability.

https://claude.ai/code/session_01NVV6pfA6rVQHgEd2vHuTnp