### PR TITLE
Simplify docs URL to use consistent raw GitHub link

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -383,10 +383,7 @@ function createTopLevelProgram(): Command {
     },
   });
 
-  // Use raw Markdown URL for pipes (AI agents), GitHub UI for TTY (humans)
-  const docsUrl = process.stdout.isTTY
-    ? `https://github.com/apify/mcpc/tree/v${mcpcVersion}`
-    : `https://raw.githubusercontent.com/apify/mcpc/v${mcpcVersion}/README.md`;
+  const docsUrl = `https://github.com/apify/mcpc/raw/refs/tags/v${mcpcVersion}/README.md`;
 
   program
     .name('mcpc')


### PR DESCRIPTION
## Summary
Unified the documentation URL handling to always use the raw GitHub content link, removing the conditional logic that previously served different URLs based on whether the output was a TTY.

## Key Changes
- Removed TTY detection logic that conditionally served either the GitHub UI tree view or raw Markdown URL
- Replaced with a single, consistent raw GitHub content URL format using the `raw/refs/tags` path
- Simplifies the codebase by eliminating the branching logic while maintaining access to documentation for both interactive and non-interactive use cases

## Implementation Details
The new URL format (`https://github.com/apify/mcpc/raw/refs/tags/v${mcpcVersion}/README.md`) provides direct access to the raw Markdown file and works reliably across different contexts (AI agents, pipes, and human users), eliminating the need for environment-specific URL selection.

https://claude.ai/code/session_01UrgrTcgdKAv1H2zXe4DYzk