### PR TITLE
Hide task:forbidden hint from tools-list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcpc help <command>` now shows a "Did you mean?" suggestion when the command is unknown (e.g., `mcpc help tasks-gfet` → suggests `tasks-get`)
 - `tools-call --task` now prints the task ID and recovery commands when interrupted with Ctrl+C, so you can fetch or cancel the server-side task later
 - `tasks-get` no longer suggests `tasks-cancel` when the task has already reached a terminal state (completed, failed, or cancelled)
+- `tools-list` no longer prints the `task:forbidden` hint on tools whose servers don't support task-augmented execution. The `task:` annotation is now only shown when the feature is available (`task:required` or `task:optional`)
 
 ### Fixed
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -266,7 +266,7 @@ export function formatToolHints(tool: Tool): string | null {
   if (annotationsStr) parts.push(annotationsStr);
 
   const taskSupport = getToolTaskSupport(tool);
-  if (taskSupport) parts.push(`task:${taskSupport}`);
+  if (taskSupport && taskSupport !== 'forbidden') parts.push(`task:${taskSupport}`);
 
   return parts.length > 0 ? parts.join(', ') : null;
 }

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -615,7 +615,7 @@ describe('formatTools', () => {
       const output = formatTools(tools);
       expect(output).toContain('`optional_tool ()` [task:optional]');
       expect(output).toContain('`required_tool ()` [task:required]');
-      expect(output).toContain('`forbidden_tool ()` [task:forbidden]');
+      expect(output).not.toContain('`forbidden_tool ()` [');
       expect(output).not.toContain('`sync_tool ()` [');
     });
 


### PR DESCRIPTION
## Summary
Updated the `formatToolHints` function to exclude the `task:forbidden` hint from tool output, ensuring that task-related annotations are only displayed when the feature is actually available to users.

## Changes
- Modified `formatToolHints()` in `src/cli/output.ts` to filter out `task:forbidden` hints by adding a condition that only includes task support information when it's not `'forbidden'`
- Updated the corresponding test in `test/unit/cli/output.test.ts` to verify that tools with forbidden task support no longer display the `[task:forbidden]` annotation
- Updated `CHANGELOG.md` to document this user-facing improvement

## Implementation Details
The change is minimal and surgical—only one condition was added to the existing check: `taskSupport && taskSupport !== 'forbidden'`. This ensures that:
- `task:required` and `task:optional` hints continue to be displayed (feature is available)
- `task:forbidden` hints are now hidden (feature is not available, no need to inform users)
- The behavior for tools without task support remains unchanged (no hint displayed)

This improves the user experience by reducing noise in the `tools-list` output while still providing useful information about available task execution capabilities.

https://claude.ai/code/session_01Vt9awhJjUu4sSLPe7NAQNs