### PR TITLE
Add OAuth state parameter to authorization URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server authentication errors now include the path to the bridge log file, so you can inspect it for more detail when investigating why a session was rejected
 - Stdio servers no longer fail silently: the bridge now captures the child's stderr, writes each line to `~/.mcpc/logs/bridge-<session>.log` with a `[server stderr]` prefix, and appends a tail of the most recent lines to `mcpc connect` errors. This makes it obvious when a stdio server crashes on startup due to e.g. missing TLS trust (`NODE_EXTRA_CA_CERTS`), missing proxy vars, or missing credentials, rather than "hanging silently" (#195)
 - `mcpc connect` now recognizes relative config-file paths with a `:entry` suffix (e.g. `docs/examples/mcp-config.json:fs`). Previously these were misinterpreted as HTTP URLs because `https://` + the path parses as a URL with the first segment as the host
+- `mcpc login` now sends a random `state` parameter on the OAuth authorization URL. Some authorization servers (e.g. Ubersuggest) reject requests without `state` with a `missing_state` error, which previously made `login` fail before reaching the consent screen (#214)
 
 ### Removed
 

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -8,6 +8,7 @@ import { createServer, type Server, type IncomingMessage, type ServerResponse } 
 import type { Socket } from 'net';
 import { URL } from 'url';
 import { createInterface } from 'readline';
+import { randomBytes } from 'crypto';
 import { auth as sdkAuth } from '@modelcontextprotocol/sdk/client/auth.js';
 import { OAuthProvider, type OAuthProviderOptions } from './oauth-provider.js';
 import { normalizeServerUrl } from '../utils.js';
@@ -503,6 +504,14 @@ export async function performOAuthFlow(
 
     // Override redirectToAuthorization to open browser
     provider.redirectToAuthorization = async (authorizationUrl: URL) => {
+      // Inject a random `state` parameter if the SDK didn't add one. OAuth 2.1 treats
+      // `state` as RECOMMENDED rather than REQUIRED, but RFC 6749 §4.1.1 allows servers
+      // to require it, and some production MCP servers do (e.g. Ubersuggest). PKCE
+      // already provides CSRF protection on this flow, so the value need not be verified.
+      if (!authorizationUrl.searchParams.has('state')) {
+        authorizationUrl.searchParams.set('state', randomBytes(16).toString('hex'));
+      }
+
       logger.debug('Opening browser for authorization...');
       // Interactive chatter goes to stderr so stdout stays clean for --json output.
       console.error(`\nAuthorization URL: ${authorizationUrl.toString()}`);


### PR DESCRIPTION
Fixes https://github.com/apify/mcpc/issues/214

## Summary
This change ensures that the OAuth authorization URL includes a `state` parameter when the SDK doesn't provide one. This fixes compatibility with authorization servers that require the `state` parameter, such as Ubersuggest.

## Key Changes
- Added import of `randomBytes` from the `crypto` module
- Modified the `redirectToAuthorization` override in `performOAuthFlow` to inject a random 16-byte hex-encoded `state` parameter if one is not already present in the authorization URL
- Updated CHANGELOG.md to document this fix

## Implementation Details
- The `state` parameter is generated using `randomBytes(16).toString('hex')`, providing a cryptographically secure random value
- The parameter is only added if the authorization URL doesn't already contain a `state` parameter, avoiding conflicts with SDK-provided values
- Per the implementation comment, while PKCE already provides CSRF protection for this flow (making state verification unnecessary), some production OAuth servers require the `state` parameter per RFC 6749 §4.1.1, even though OAuth 2.1 treats it as RECOMMENDED

https://claude.ai/code/session_01DvJvUuWwHBT4VWoUZoqFhL