### PR TITLE
Add badges to README for npm, downloads, CI, and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ![mcpc logo](https://apify.github.io/mcpc/client-logo.svg?v=2)
 
+[![npm version](https://img.shields.io/npm/v/@apify/mcpc.svg)](https://www.npmjs.com/package/@apify/mcpc)
+[![npm downloads](https://img.shields.io/npm/dm/@apify/mcpc.svg)](https://www.npmjs.com/package/@apify/mcpc)
+[![CI](https://github.com/apify/mcpc/actions/workflows/ci.yml/badge.svg)](https://github.com/apify/mcpc/actions/workflows/ci.yml)
+[![License](https://img.shields.io/npm/l/@apify/mcpc.svg)](https://github.com/apify/mcpc/blob/main/LICENSE)
+
 `mcpc` is a command-line client for the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
 that maps MCP operations to intuitive commands for interactive shell use, scripting, and AI agents.
 


### PR DESCRIPTION
## Summary
Added status badges to the README to improve project visibility and provide quick access to important project information.

## Changes
- Added npm version badge linking to the package on npmjs.com
- Added npm downloads badge showing monthly download statistics
- Added CI workflow badge linking to GitHub Actions CI pipeline
- Added license badge linking to the LICENSE file

These badges are now displayed prominently at the top of the README, right after the project logo, making it easy for users to see the package version, popularity, build status, and licensing information at a glance.

https://claude.ai/code/session_01TsDZZrHnhza8smuqusZawj