### PR TITLE
Reduce OAuth callback ports from 6 to 3 for better port allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- OAuth callback ports for the hosted CIMD changed from the contiguous range 13316–13325 to 6 non-contiguous ports (13316, 13163, 31316, 31613, 16133, 16313) so one unrelated process is less likely to claim all of them. `localhost` variants dropped from the CIMD's `redirect_uris` in favor of `127.0.0.1` only (per RFC 8252 §8.3, which recommends the IP literal to avoid DNS resolution ambiguity).
+- OAuth callback ports for the hosted CIMD changed from the contiguous range 13316–13325 to 3 non-contiguous ports (13316, 31613, 16133) so one unrelated process is less likely to claim all of them. `localhost` variants dropped from the CIMD's `redirect_uris` in favor of `127.0.0.1` only (per RFC 8252 §8.3, which recommends the IP literal to avoid DNS resolution ambiguity).
 - Stdio (command-based) config entries are now skipped by default when connecting from a config file (`mcpc connect <file>`). Pass `--stdio` to include them. Single-entry connects (`mcpc connect file:entry @session`) are not affected.
 - `restart` success message now notes that previous session state (resource subscriptions, pending notifications, async tasks) was lost, since explicit restart always creates a fresh MCP session
 - `tasks-list` now shows a hint on how to start a new task (`mcpc @session tools-call <name> [args] --task`) when there are no active tasks

--- a/client-metadata.json
+++ b/client-metadata.json
@@ -5,11 +5,8 @@
   "tos_uri": "https://apify.github.io/mcpc/LICENSE",
   "redirect_uris": [
     "http://127.0.0.1:13316/callback",
-    "http://127.0.0.1:13163/callback",
-    "http://127.0.0.1:31316/callback",
     "http://127.0.0.1:31613/callback",
-    "http://127.0.0.1:16133/callback",
-    "http://127.0.0.1:16313/callback"
+    "http://127.0.0.1:16133/callback"
   ],
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],

--- a/src/lib/auth/oauth-utils.ts
+++ b/src/lib/auth/oauth-utils.ts
@@ -19,9 +19,7 @@ export const DEFAULT_CLIENT_METADATA_URL = 'https://apify.github.io/mcpc/client-
  * the first available port is used. Non-contiguous values to reduce the
  * chance that a single unrelated process claims all of them.
  */
-export const MCPC_OAUTH_CALLBACK_PORTS: readonly number[] = [
-  13316, 13163, 31316, 31613, 16133, 16313,
-] as const;
+export const MCPC_OAUTH_CALLBACK_PORTS: readonly number[] = [13316, 31613, 16133] as const;
 
 /**
  * OAuth token endpoint response (per OAuth 2.0 spec - uses snake_case)

--- a/test/unit/lib/auth/oauth-utils.test.ts
+++ b/test/unit/lib/auth/oauth-utils.test.ts
@@ -2,7 +2,12 @@
  * Unit tests for OAuth utility functions
  */
 
-import { discoverTokenEndpoint } from '../../../../src/lib/auth/oauth-utils.js';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import {
+  discoverTokenEndpoint,
+  MCPC_OAUTH_CALLBACK_PORTS,
+} from '../../../../src/lib/auth/oauth-utils.js';
 import * as proxyModule from '../../../../src/lib/proxy.js';
 
 // Helper to create a mock fetch Response
@@ -145,5 +150,39 @@ describe('discoverTokenEndpoint', () => {
       'https://example.com/.well-known/oauth-authorization-server',
       'https://example.com/.well-known/openid-configuration',
     ]);
+  });
+});
+
+describe('MCPC_OAUTH_CALLBACK_PORTS / client-metadata.json consistency', () => {
+  const PROJECT_ROOT = resolve(__dirname, '../../../..');
+  const metadata = JSON.parse(
+    readFileSync(resolve(PROJECT_ROOT, 'client-metadata.json'), 'utf-8')
+  ) as { redirect_uris: string[] };
+
+  it('every callback port has a matching loopback redirect_uri in client-metadata.json', () => {
+    const expectedUris = MCPC_OAUTH_CALLBACK_PORTS.map(
+      (port) => `http://127.0.0.1:${port}/callback`
+    );
+    for (const uri of expectedUris) {
+      expect(metadata.redirect_uris).toContain(uri);
+    }
+  });
+
+  it('every redirect_uri in client-metadata.json corresponds to a callback port', () => {
+    const allowedUris = new Set(
+      MCPC_OAUTH_CALLBACK_PORTS.map((port) => `http://127.0.0.1:${port}/callback`)
+    );
+    for (const uri of metadata.redirect_uris) {
+      expect(allowedUris.has(uri)).toBe(true);
+    }
+  });
+
+  it('the count of redirect_uris matches the count of callback ports', () => {
+    expect(metadata.redirect_uris.length).toBe(MCPC_OAUTH_CALLBACK_PORTS.length);
+  });
+
+  it('callback ports are unique', () => {
+    const unique = new Set(MCPC_OAUTH_CALLBACK_PORTS);
+    expect(unique.size).toBe(MCPC_OAUTH_CALLBACK_PORTS.length);
   });
 });


### PR DESCRIPTION
## Summary
This PR reduces the number of OAuth callback ports used by the MCPC client from 6 to 3, improving port allocation efficiency while maintaining non-contiguous spacing to prevent a single process from claiming all available ports.

## Changes
- **OAuth callback ports**: Reduced from `[13316, 13163, 31316, 31613, 16133, 16313]` to `[13316, 31613, 16133]`
  - Removed ports: 13163, 31316, 16313
  - Maintains non-contiguous spacing to reduce collision risk with unrelated processes
  
- **Client metadata**: Updated `redirect_uris` in `client-metadata.json` to match the new port list
  - Removed corresponding callback URIs for the eliminated ports
  - Keeps only the 3 active ports for OAuth redirects

- **Documentation**: Updated CHANGELOG.md to reflect the port reduction from 6 to 3

## Implementation Details
The change simplifies the OAuth callback port configuration while maintaining the original design principle of using non-contiguous ports to minimize the likelihood of a single unrelated process claiming all available callback ports. This reduces resource overhead without compromising the robustness of the OAuth flow.

https://claude.ai/code/session_01MBkeTp3rJeBNYqycYLKcsq