### PR TITLE
Fix bridge auto-reconnect to persist unauthorized status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bridge processes started by `mcpc`'s background auto-reconnect now correctly mark sessions as `unauthorized` when the server returns 401/403. Previously the bridge crashed (unhandled promise rejection) before persisting the failure status, so `mcpc` listings kept showing the session as `connecting` until the user explicitly accessed it
 - Sessions using a static bearer token (via `--header "Authorization: ..."`) no longer flip between `unauthorized` and `connecting` on every `mcpc` invocation — they stay `unauthorized` since retrying the same rejected token cannot succeed without `mcpc login` or reconnecting. OAuth-profile sessions still auto-retry because tokens may have been refreshed by another session
 - Server authentication errors now include the path to the bridge log file, so you can inspect it for more detail when investigating why a session was rejected
 - Stdio servers no longer fail silently: the bridge now captures the child's stderr, writes each line to `~/.mcpc/logs/bridge-<session>.log` with a `[server stderr]` prefix, and appends a tail of the most recent lines to `mcpc connect` errors. This makes it obvious when a stdio server crashes on startup due to e.g. missing TLS trust (`NODE_EXTRA_CA_CERTS`), missing proxy vars, or missing credentials, rather than "hanging silently" (#195)

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -143,6 +143,11 @@ class BridgeProcess {
       this.mcpClientReadyResolver = resolve;
       this.mcpClientReadyRejecter = reject;
     });
+    // Mark the promise as handled so a rejection without a current awaiter
+    // (e.g. auto-restart bridge with no connected IPC client) doesn't crash
+    // the bridge before it can persist the failure status to sessions.json.
+    // Subsequent `await this.mcpClientReady` calls still see the rejection.
+    this.mcpClientReady.catch(() => {});
 
     if (options.verbose) {
       setVerbose(true);

--- a/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
+++ b/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Test: A crashed bearer-token session whose bridge gets a 401 on auto-reconnect
+# is automatically promoted to 'unauthorized' without the user having to access
+# the session first.
+#
+# Regression: previously, `mcpc` (the listing command) only fired-and-forgot
+# the auto-restart and showed 'connecting' indefinitely until the user ran a
+# command on the session, which would explicitly trigger ensureBridgeReady() and
+# only then surface the auth error. The fix ensures the bridge's own status
+# update (status: 'unauthorized') propagates so subsequent `mcpc` calls reflect
+# reality without explicit interaction.
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "sessions/unauthorized-auto-detect" --isolated
+
+start_test_server REQUIRE_AUTH=true
+
+SESSION=$(session_name "auto-detect")
+_SESSIONS_CREATED+=("$SESSION")
+
+# =============================================================================
+# Setup: produce a session in 'crashed' state with bad bearer
+#
+# We can't just `mcpc connect` with a bad bearer because that produces an
+# 'unauthorized' status directly (showServerDetails surfaces the error during
+# connect). To simulate the reported scenario — a bridge that crashed (e.g. on
+# machine reboot) and now gets a 401 on its auto-restart attempt — we connect
+# successfully against a temporarily-permissive server, then kill the bridge
+# and edit sessions.json to look like a freshly-crashed bridge with bad creds.
+# =============================================================================
+
+test_case "create session with valid bearer, then simulate crashed state with bad bearer"
+
+# Connect with a valid bearer — server accepts any "Bearer <token>" shape
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION" \
+  --header "X-Test: true" \
+  --header "Authorization: Bearer good-token"
+assert_success
+
+# Stop the bridge process so it's no longer running
+run_mcpc "$SESSION" close
+assert_success
+
+# Recreate the session record by hand — sessions.json after `close` deletes
+# the entry, so we re-add it directly in the state we want to test:
+# - status: 'crashed' (no pid alive)
+# - lastConnectionAttemptAt aged past the 10s auto-retry cooldown
+# - bad Authorization header so the auto-restart hits 401
+sessions_file="$MCPC_HOME_DIR/sessions.json"
+old_iso="2000-01-01T00:00:00.000Z"
+tmp_file="$TEST_TMP/sessions.json.$$"
+
+# Save bad headers to the keychain used by restartBridge on auto-reconnect
+# (headers are loaded from the keychain, not sessions.json, on restart).
+node -e "
+  process.env.MCPC_HOME_DIR = '$MCPC_HOME_DIR';
+  const { storeKeychainSessionHeaders } = require('$PROJECT_ROOT/dist/lib/auth/keychain.js');
+  storeKeychainSessionHeaders('$SESSION', {
+    'X-Test': 'true',
+    'Authorization': 'InvalidScheme not-a-bearer-token'
+  }).catch(e => { console.error(e); process.exit(1); });
+"
+
+# Reconstruct the session entry: crashed state, no pid, old attempt timestamp,
+# headers placeholder so the restart path knows to load headers from keychain.
+jq --arg name "$SESSION" \
+   --arg url "$TEST_SERVER_URL" \
+   --arg when "$old_iso" \
+   '.sessions[$name] = {
+      "name": $name,
+      "server": {
+        "url": $url,
+        "headers": { "X-Test": "<redacted>", "Authorization": "<redacted>" }
+      },
+      "transport": "http",
+      "createdAt": $when,
+      "lastConnectionAttemptAt": $when,
+      "status": "crashed"
+    }' \
+  "$sessions_file" > "$tmp_file"
+mv "$tmp_file" "$sessions_file"
+
+test_pass
+
+# =============================================================================
+# Test: a single `mcpc` listing triggers an auto-restart that propagates the
+# 'unauthorized' status within a reasonable window (no explicit session access
+# required to surface the auth error).
+# =============================================================================
+
+test_case "auto-reconnect from crashed -> unauthorized without explicit access"
+
+# Trigger auto-reconnect (fire-and-forget) via the listing command.
+run_mcpc --json
+assert_success
+
+# Poll the session status: it should transition to 'unauthorized' once the
+# bridge spawned by the listing's fire-and-forget reconnect completes its
+# initial handshake and gets a 401. Allow up to 15s for the bridge spawn,
+# IPC creds, MCP initialize, and 401 response to complete.
+deadline=$((SECONDS + 15))
+final_status=""
+while (( SECONDS < deadline )); do
+  run_mcpc --json
+  final_status=$(echo "$STDOUT" | jq -r ".sessions[] | select(.name == \"$SESSION\") | .status")
+  if [[ "$final_status" == "unauthorized" ]]; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ "$final_status" != "unauthorized" ]]; then
+  test_fail "expected status 'unauthorized' within 15s, got: '$final_status'"
+  exit 1
+fi
+test_pass
+
+test_done


### PR DESCRIPTION
## Summary
Bridge processes started by `mcpc`'s background auto-reconnect now correctly mark sessions as `unauthorized` when the server returns 401/403, without requiring explicit user interaction to surface the auth error.

## Problem
Previously, when a bridge crashed and attempted to auto-reconnect, an unhandled promise rejection would cause the bridge to crash before it could persist the failure status to `sessions.json`. This meant `mcpc list` would show the session as "connecting" indefinitely until the user explicitly accessed the session, which would trigger `ensureBridgeReady()` and surface the auth error.

## Solution
- **Bridge process**: Added a catch handler to the `mcpClientReady` promise to prevent unhandled rejections from crashing the bridge before it can persist the failure status. The catch handler is empty (fire-and-forget) since subsequent `await this.mcpClientReady` calls still properly see the rejection.
- **Test coverage**: Added comprehensive e2e test that verifies a crashed session with invalid credentials automatically transitions to `unauthorized` status within 15 seconds of a listing command, without requiring explicit session access.

## Key Changes
- Modified `src/bridge/index.ts`: Added `.catch(() => {})` handler to `mcpClientReady` promise to prevent unhandled rejections
- Added `test/e2e/suites/sessions/unauthorized-auto-detect.test.sh`: End-to-end test that simulates a crashed bridge with bad credentials and verifies the status propagates correctly
- Updated `CHANGELOG.md`: Documented the fix

## Implementation Details
The fix is minimal and surgical: by attaching an empty catch handler to the promise at creation time, we prevent Node.js from treating a rejection as unhandled while still allowing all subsequent `await` statements on that promise to properly receive and handle the rejection.

https://claude.ai/code/session_01GRC1iU4fnBYurX28RRmybQ