### PR TITLE
Add Motivation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ integrating an MCP SDK or wiring up dozens of client functions. Just one `Bash()
 `mcpc` does the rest:
 
 ```
-                              MCP                               MCP
+                             Bash()                              MCP
    ┌──────────┐                                  ┌──────┐                  ┌────────────┐
    │ AI agent │  ─────────────────────────────►  │ mcpc │  ──────────────► │ MCP server │
    └──────────┘                                  └──────┘                  └────────────┘
-                    Tools + Tasks, Resources, Prompts,
-                    Sessions, OAuth, Notifications
+                                                          Tools + Tasks, Resources, Prompts,
+                                                          Sessions, OAuth, Notifications
 ```
 
 CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ coding interface: the UNIX shell.
 
 ## Motivation
 
-Most AI agents misuse MCP, treating tools as prompt-time function calls: tool definitions and results
-are repeatedly injected into the agent's context, tokens are wasted, and context rots.
-The result is slower, less reliable agents — and the misleading conclusion that
-*"MCP sucks, CLIs are better"*.
+Most AI agents misuse MCP. They treat tools as prompt-time function calls, repeatedly injecting
+tool definitions and results into the agent's context. Tokens get wasted, context rots, and the
+agent gets slower and less reliable. Hence the popular conclusion: *"MCP sucks, CLIs are better"*.
 
 `mcpc` challenges that narrative. It maps every MCP operation to an intuitive CLI command that
-agents pick up from `--help` alone. Any agent with shell access gets full MCP support — no MCP SDK
-integration, no dozens of client functions to wire up — just one `Bash()` tool, and `mcpc` does the rest:
+agents pick up from `--help` alone. Any agent with shell access gets full MCP support without
+integrating an MCP SDK or wiring up dozens of client functions. Just one `Bash()` tool, and
+`mcpc` does the rest:
 
 ```
                                                  ┌───────────────────────────┐
@@ -73,7 +73,7 @@ integration, no dozens of client functions to wire up — just one `Bash()` tool
 
 CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the
 standard *remote* interface for server discovery, authentication, payments, and access control.
-The two aren't exclusive — they're complementary.
+The two aren't exclusive. They're complementary.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ coding interface: the UNIX shell.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Motivation](#motivation)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Usage](#usage)
@@ -44,6 +45,38 @@ coding interface: the UNIX shell.
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Motivation
+
+Most AI agents misuse MCP and treat tools as prompt-time function calls: tool definitions and results
+are repeatedly injected into the agent's context, tokens are wasted, and context rots.
+The result is slower, less reliable agents — and the misleading conclusion that
+*"MCP sucks, CLIs are better"*.
+
+`mcpc` challenges that narrative. It maps every MCP operation to an intuitive CLI command that
+agents pick up through `--help` alone, with no external skills, prompts, or documentation required.
+The agent reaches the entire MCP protocol — tools, resources, prompts, async tasks, OAuth,
+notifications, code mode, progressive tool discovery — through a single `Bash()` tool call:
+
+```
+                                                ┌───────────────────────────┐
+                                                │  • Tools                  │
+   ┌──────────┐                  ┌──────┐       │  • Resources              │
+   │ AI agent │  ── Bash() ───►  │      │ ─MCP─►│  • Prompts                │
+   │  Claude  │                  │      │       │  • Async tasks            │
+   │  Code,   │                  │ mcpc │       │  • OAuth 2.1 / x402       │
+   │  Codex,  │                  │      │       │  • Notifications          │
+   │  ...     │  ◄── stdout ───  │      │ ◄MCP─ │  • Progressive discovery  │
+   └──────────┘                  └──────┘       │  • Code mode              │
+                                                └───────────────────────────┘
+                                                  any MCP server (HTTP/stdio)
+```
+
+It turns out CLI is the perfect *local* interface for agents to interact with MCP: full protocol
+coverage and modern features through a single `Bash()` call, while still leveraging MCP's standard
+*remote* interface for server discovery, authentication, payments, and access control.
+
+CLI and MCP aren't exclusive — they're complementary.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,13 @@ coding interface: the UNIX shell.
 
 ## Motivation
 
-Most AI agents misuse MCP and treat tools as prompt-time function calls: tool definitions and results
+Most AI agents misuse MCP, treating tools as prompt-time function calls: tool definitions and results
 are repeatedly injected into the agent's context, tokens are wasted, and context rots.
 The result is slower, less reliable agents — and the misleading conclusion that
 *"MCP sucks, CLIs are better"*.
 
 `mcpc` challenges that narrative. It maps every MCP operation to an intuitive CLI command that
-agents pick up through `--help` alone, with no external skills, prompts, or documentation required.
-The agent reaches the entire MCP protocol — tools, resources, prompts, async tasks, OAuth,
-notifications, code mode, progressive tool discovery — through a single `Bash()` tool call:
+agents pick up from `--help` alone, exposing the entire protocol through a single `Bash()` tool call:
 
 ```
                                                  ┌───────────────────────────┐
@@ -71,11 +69,9 @@ notifications, code mode, progressive tool discovery — through a single `Bash(
                                                    any MCP server (HTTP/stdio)
 ```
 
-It turns out CLI is the perfect *local* interface for agents to interact with MCP: full protocol
-coverage and modern features through a single `Bash()` call, while still leveraging MCP's standard
-*remote* interface for server discovery, authentication, payments, and access control.
-
-CLI and MCP aren't exclusive — they're complementary.
+CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the
+standard *remote* interface for server discovery, authentication, payments, and access control.
+The two aren't exclusive — they're complementary.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ notifications, code mode, progressive tool discovery — through a single `Bash(
                                                 ┌───────────────────────────┐
                                                 │  • Tools                  │
    ┌──────────┐                  ┌──────┐       │  • Resources              │
-   │ AI agent │  ── Bash() ───►  │      │ ─MCP─►│  • Prompts                │
-   │  Claude  │                  │      │       │  • Async tasks            │
-   │  Code,   │                  │ mcpc │       │  • OAuth 2.1 / x402       │
-   │  Codex,  │                  │      │       │  • Notifications          │
-   │  ...     │  ◄── stdout ───  │      │ ◄MCP─ │  • Progressive discovery  │
-   └──────────┘                  └──────┘       │  • Code mode              │
-                                                └───────────────────────────┘
+   │ AI agent │                  │      │       │  • Prompts                │
+   │  Claude  │  ── Bash() ───►  │ mcpc │ ─MCP─►│  • Sessions               │
+   │  Code,   │                  │      │       │  • Async tasks            │
+   │  Codex,  │                  │      │       │  • OAuth 2.1 / x402       │
+   │  ...     │                  └──────┘       │  • Notifications          │
+   └──────────┘                                 └───────────────────────────┘
                                                   any MCP server (HTTP/stdio)
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ CLI turns out to be the perfect *local* interface between agents and MCP, while 
 standard *remote* interface for server discovery, authentication, payments, and access control.
 The two aren't exclusive. They're complementary.
 
+As a bonus, the same `mcpc` configuration, OAuth profiles, and live sessions can be shared across
+many AI agents on the same machine. Authenticate once, reuse everywhere.
+
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -54,19 +54,21 @@ The result is slower, less reliable agents — and the misleading conclusion tha
 *"MCP sucks, CLIs are better"*.
 
 `mcpc` challenges that narrative. It maps every MCP operation to an intuitive CLI command that
-agents pick up from `--help` alone, exposing the entire protocol through a single `Bash()` tool call:
+agents pick up from `--help` alone. Any agent with shell access gets full MCP support — no MCP SDK
+integration, no dozens of client functions to wire up — just one `Bash()` tool, and `mcpc` does the rest:
 
 ```
                                                  ┌───────────────────────────┐
                                                  │  • Tools                  │
-   ┌──────────┐                  ┌──────┐        │  • Resources              │
-   │ AI agent │      Bash()      │      │  MCP   │  • Prompts                │
-   │  Claude  │   ───────────►   │ mcpc │ ─────► │  • Sessions               │
-   │  Code,   │                  │      │        │  • Async tasks            │
-   │  Codex,  │                  │      │        │  • OAuth 2.1 / x402       │
-   │  ...     │                  └──────┘        │  • Notifications          │
+   ┌──────────┐                                  │  • Resources              │
+   │ AI agent │      Bash()       ┌──────┐  MCP  │  • Prompts                │
+   │  Claude  │   ────────────►   │ mcpc │ ────► │  • Sessions               │
+   │  Code,   │                   │      │       │  • Async tasks            │
+   │  Codex,  │                   │      │       │  • OAuth 2.1 / x402       │
+   │  ...     │                   └──────┘       │  • Notifications          │
    └──────────┘                                  └───────────────────────────┘
-                                                   any MCP server (HTTP/stdio)
+    one tool                  full MCP SDK         any MCP server (HTTP/stdio)
+                              handled by mcpc
 ```
 
 CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ integrating an MCP SDK or wiring up dozens of client functions. Just one `Bash()
    ┌──────────┐                                  ┌──────┐                  ┌────────────┐
    │ AI agent │  ─────────────────────────────►  │ mcpc │  ──────────────► │ MCP server │
    └──────────┘                                  └──────┘                  └────────────┘
-                                                          Tools + Tasks, Resources, Prompts,
-                                                          Sessions, OAuth, Notifications
+                                                          Sessions, tools,
+                                                          resources, prompts,
+                                                          tasks, x402, discovery,
+                                                          ...
 ```
 
 CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the

--- a/README.md
+++ b/README.md
@@ -48,24 +48,21 @@ coding interface: the UNIX shell.
 
 ## Motivation
 
-Most AI agents misuse MCP. They treat tools as prompt-time function calls, repeatedly injecting
-tool definitions and results into the agent's context. Tokens get wasted, context rots, and the
+Many AI agents misuse MCP. They treat tools as prompt-time function calls, repeatedly injecting
+tool definitions and results into the context. Tokens get wasted, context rots, and the
 agent gets slower and less reliable. Hence the popular conclusion: *"MCP sucks, CLIs are better"*.
 
 `mcpc` challenges that narrative. It maps every MCP operation to an intuitive CLI command that
 agents pick up from `--help` alone. Any agent with shell access gets full MCP support without
-integrating an MCP SDK or wiring up dozens of client functions. Just one `Bash()` tool, and
-`mcpc` does the rest:
+wiring up dozens of MCP functions. Just one `Bash()` tool, and `mcpc` does the rest:
 
-```
-                             Bash()                              MCP
-   ┌──────────┐                                  ┌──────┐                  ┌────────────┐
-   │ AI agent │  ─────────────────────────────►  │ mcpc │  ──────────────► │ MCP server │
-   └──────────┘                                  └──────┘                  └────────────┘
-                                                          Sessions, tools,
-                                                          resources, prompts,
-                                                          tasks, x402, discovery,
-                                                          ...
+```                                                           
+   ┌──────────┐     Bash()    ┌────────┐          MCP         ┌────────────┐
+   │ AI agent │  ───────────► │  mcpc  │  ──────────────────► │ MCP server │
+   └──────────┘               └────────┘   Sessions, OAuth,   └────────────┘
+                                           Tools, Resources,
+                                           Prompts, Tasks,
+                                           x402, ...
 ```
 
 CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the

--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ The agent reaches the entire MCP protocol — tools, resources, prompts, async t
 notifications, code mode, progressive tool discovery — through a single `Bash()` tool call:
 
 ```
-                                                ┌───────────────────────────┐
-                                                │  • Tools                  │
-   ┌──────────┐                  ┌──────┐       │  • Resources              │
-   │ AI agent │                  │      │       │  • Prompts                │
-   │  Claude  │  ── Bash() ───►  │ mcpc │ ─MCP─►│  • Sessions               │
-   │  Code,   │                  │      │       │  • Async tasks            │
-   │  Codex,  │                  │      │       │  • OAuth 2.1 / x402       │
-   │  ...     │                  └──────┘       │  • Notifications          │
-   └──────────┘                                 └───────────────────────────┘
-                                                  any MCP server (HTTP/stdio)
+                                                 ┌───────────────────────────┐
+                                                 │  • Tools                  │
+   ┌──────────┐                  ┌──────┐        │  • Resources              │
+   │ AI agent │      Bash()      │      │  MCP   │  • Prompts                │
+   │  Claude  │   ───────────►   │ mcpc │ ─────► │  • Sessions               │
+   │  Code,   │                  │      │        │  • Async tasks            │
+   │  Codex,  │                  │      │        │  • OAuth 2.1 / x402       │
+   │  ...     │                  └──────┘        │  • Notifications          │
+   └──────────┘                                  └───────────────────────────┘
+                                                   any MCP server (HTTP/stdio)
 ```
 
 It turns out CLI is the perfect *local* interface for agents to interact with MCP: full protocol

--- a/README.md
+++ b/README.md
@@ -58,17 +58,12 @@ integrating an MCP SDK or wiring up dozens of client functions. Just one `Bash()
 `mcpc` does the rest:
 
 ```
-                                                 ┌───────────────────────────┐
-                                                 │  • Tools                  │
-   ┌──────────┐                                  │  • Resources              │
-   │ AI agent │      Bash()       ┌──────┐  MCP  │  • Prompts                │
-   │  Claude  │   ────────────►   │ mcpc │ ────► │  • Sessions               │
-   │  Code,   │                   │      │       │  • Async tasks            │
-   │  Codex,  │                   │      │       │  • OAuth 2.1 / x402       │
-   │  ...     │                   └──────┘       │  • Notifications          │
-   └──────────┘                                  └───────────────────────────┘
-    one tool                  full MCP SDK         any MCP server (HTTP/stdio)
-                              handled by mcpc
+                              MCP                               MCP
+   ┌──────────┐                                  ┌──────┐                  ┌────────────┐
+   │ AI agent │  ─────────────────────────────►  │ mcpc │  ──────────────► │ MCP server │
+   └──────────┘                                  └──────┘                  └────────────┘
+                    Tools + Tasks, Resources, Prompts,
+                    Sessions, OAuth, Notifications
 ```
 
 CLI turns out to be the perfect *local* interface between agents and MCP, while MCP remains the


### PR DESCRIPTION
## Summary
Added a new "Motivation" section to the README that explains the philosophy and design rationale behind `mcpc`.

## Changes
- Added "Motivation" entry to the table of contents
- Introduced a new "Motivation" section that covers:
  - The problem with how AI agents typically misuse MCP (treating tools as prompt-time function calls, wasting tokens, degrading reliability)
  - How `mcpc` solves this by mapping MCP operations to intuitive CLI commands
  - A visual diagram showing how `mcpc` acts as a bridge between AI agents and MCP servers via Bash
  - The complementary relationship between CLI (local interface) and MCP (remote interface)
  - The benefit of sharing `mcpc` configuration and sessions across multiple AI agents

## Details
The motivation section provides context for why `mcpc` exists and its core value proposition: enabling AI agents to access MCP functionality through a simple CLI interface without the overhead and inefficiency of traditional prompt-based tool injection patterns.

https://claude.ai/code/session_01NCbJaYm7LuEL2mEPXTnzsb