### PR TITLE
fix: increase bridge IPC credential timeout for macOS Keychain

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -406,9 +406,10 @@ class BridgeProcess {
       }
 
       if (ipcWaiters.length > 0) {
-        // Wait with timeout (60 seconds to allow for interactive macOS Keychain prompts)
+        const ipcTimeoutMs = process.env.MCPC_IPC_TIMEOUT_MS ? parseInt(process.env.MCPC_IPC_TIMEOUT_MS, 10) : 60_000;
+        logger.info(`Waiting for IPC credentials (${ipcTimeoutMs / 1000}s timeout, check for background password prompts)...`);
         const timeout = new Promise<void>((_, reject) => {
-          setTimeout(() => reject(new Error('Timeout waiting for IPC credentials')), 60000);
+          setTimeout(() => reject(new Error('Timeout waiting for IPC credentials')), ipcTimeoutMs);
         });
         await Promise.race([Promise.all(ipcWaiters), timeout]);
         logger.debug('IPC credentials received, proceeding with MCP connection');

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -406,9 +406,9 @@ class BridgeProcess {
       }
 
       if (ipcWaiters.length > 0) {
-        // Wait with timeout (5 seconds should be plenty for local IPC)
+        // Wait with timeout (60 seconds to allow for interactive macOS Keychain prompts)
         const timeout = new Promise<void>((_, reject) => {
-          setTimeout(() => reject(new Error('Timeout waiting for IPC credentials')), 5000);
+          setTimeout(() => reject(new Error('Timeout waiting for IPC credentials')), 60000);
         });
         await Promise.race([Promise.all(ipcWaiters), timeout]);
         logger.debug('IPC credentials received, proceeding with MCP connection');


### PR DESCRIPTION
## Summary
Bumped the bridge IPC credential timeout from 5 to 60 seconds and made it configurable via `MCPC_IPC_TIMEOUT_MS`. When macOS Keychain needs a password, the interactive dialog takes longer than 5 seconds, causing ENOENT errors on reconnect.

## Changes
- Replaced hardcoded 5s timeout with configurable value (default 60s)
- Added info log before credential wait so users know the app isn't frozen
- Added `MCPC_IPC_TIMEOUT_MS` env var override for CI environments

Fixes #55