### PR TITLE
Add atomic rename with retry logic for Windows file lock issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stdio servers no longer fail silently: the bridge now captures the child's stderr, writes each line to `~/.mcpc/logs/bridge-<session>.log` with a `[server stderr]` prefix, and appends a tail of the most recent lines to `mcpc connect` errors. This makes it obvious when a stdio server crashes on startup due to e.g. missing TLS trust (`NODE_EXTRA_CA_CERTS`), missing proxy vars, or missing credentials, rather than "hanging silently" (#195)
 - `mcpc connect` now recognizes relative config-file paths with a `:entry` suffix (e.g. `docs/examples/mcp-config.json:fs`). Previously these were misinterpreted as HTTP URLs because `https://` + the path parses as a URL with the first segment as the host
 - `mcpc login` now sends a random `state` parameter on the OAuth authorization URL. Some authorization servers (e.g. Ubersuggest) reject requests without `state` with a `missing_state` error, which previously made `login` fail before reaching the consent screen (#214)
+- `mcpc connect` no longer aborts on Windows with `Failed to save sessions: EPERM: operation not permitted, rename …` when antivirus or another mcpc process briefly holds `sessions.json` open. The atomic rename used to persist `sessions.json`, `profiles.json`, and `wallets.json` now retries transient Windows file-lock errors with a short backoff
 
 ### Removed
 

--- a/src/lib/auth/profiles.ts
+++ b/src/lib/auth/profiles.ts
@@ -4,7 +4,7 @@
  * Uses file locking to prevent concurrent access issues
  */
 
-import { readFile, writeFile, rename, unlink } from 'fs/promises';
+import { readFile, writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import type { AuthProfile, AuthProfilesStorage } from '../types.js';
 import {
@@ -13,6 +13,7 @@ import {
   ensureDir,
   getMcpcHome,
   getServerHost,
+  atomicRename,
 } from '../utils.js';
 import { loadSessions } from '../sessions.js';
 import { withFileLock } from '../file-lock.js';
@@ -70,8 +71,8 @@ async function saveAuthProfilesInternal(storage: AuthProfilesStorage): Promise<v
     const content = JSON.stringify(storage, null, 2);
     await writeFile(tempFile, content, { encoding: 'utf-8', mode: 0o600 });
 
-    // Atomic rename
-    await rename(tempFile, filePath);
+    // Atomic rename (retries on Windows EPERM/EBUSY from transient file locks)
+    await atomicRename(tempFile, filePath);
 
     logger.debug('Auth profiles saved successfully');
   } catch (error) {

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -4,7 +4,7 @@
  * Uses file locking to prevent concurrent access issues
  */
 
-import { readFile, writeFile, rename, unlink } from 'fs/promises';
+import { readFile, writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import type { SessionData, SessionsStorage } from './types.js';
 import {
@@ -14,6 +14,7 @@ import {
   ensureDir,
   getMcpcHome,
   isProcessAlive,
+  atomicRename,
 } from './utils.js';
 import { withFileLock } from './file-lock.js';
 import { createLogger } from './logger.js';
@@ -68,8 +69,8 @@ async function saveSessionsInternal(storage: SessionsStorage): Promise<void> {
     const content = JSON.stringify(storage, null, 2);
     await writeFile(tempFile, content, { encoding: 'utf-8', mode: 0o600 });
 
-    // Atomic rename
-    await rename(tempFile, filePath);
+    // Atomic rename (retries on Windows EPERM/EBUSY from transient file locks)
+    await atomicRename(tempFile, filePath);
 
     logger.debug('Sessions saved successfully');
   } catch (error) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,7 @@ import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { homedir } from 'os';
 import { join, resolve, isAbsolute } from 'path';
-import { mkdir, access, constants } from 'fs/promises';
+import { mkdir, access, constants, rename } from 'fs/promises';
 import { ClientError } from './errors.js';
 
 /**
@@ -330,6 +330,36 @@ export function isValidResourceUri(uri: string): boolean {
  */
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Rename a file atomically with retry on transient Windows errors.
+ *
+ * On Windows, `rename()` can fail with EPERM/EBUSY/EACCES when the destination
+ * file is briefly held open by another process (antivirus scanner, a sibling
+ * mcpc bridge re-reading sessions.json, etc.). The failure window is short, so
+ * a few quick retries with a small backoff are enough to recover.
+ */
+export async function atomicRename(src: string, dest: string): Promise<void> {
+  const transientCodes = new Set(['EPERM', 'EBUSY', 'EACCES']);
+  const maxAttempts = process.platform === 'win32' ? 10 : 1;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await rename(src, dest);
+      return;
+    } catch (error) {
+      lastError = error;
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!code || !transientCodes.has(code) || attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(20 * attempt);
+    }
+  }
+
+  throw lastError;
 }
 
 /**

--- a/src/lib/wallets.ts
+++ b/src/lib/wallets.ts
@@ -3,10 +3,10 @@
  * Stores a single wallet in ~/.mcpc/wallets.json
  */
 
-import { readFile, writeFile, rename, unlink } from 'fs/promises';
+import { readFile, writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import type { WalletData, WalletsStorage } from './types.js';
-import { getWalletsFilePath, fileExists, ensureDir, getMcpcHome } from './utils.js';
+import { getWalletsFilePath, fileExists, ensureDir, getMcpcHome, atomicRename } from './utils.js';
 import { withFileLock } from './file-lock.js';
 import { ClientError } from './errors.js';
 import {
@@ -48,7 +48,7 @@ async function saveStorageInternal(storage: WalletsStorage): Promise<void> {
   const tempFile = join(getMcpcHome(), `.wallets-${Date.now()}-${process.pid}.tmp`);
   try {
     await writeFile(tempFile, JSON.stringify(storage, null, 2), { encoding: 'utf-8', mode: 0o600 });
-    await rename(tempFile, filePath);
+    await atomicRename(tempFile, filePath);
   } catch (error) {
     try {
       await unlink(tempFile);

--- a/test/e2e/suites/basic/connect-discover.test.sh
+++ b/test/e2e/suites/basic/connect-discover.test.sh
@@ -114,7 +114,10 @@ _SESSIONS_CREATED+=("@discover-global")
 
 run_mcpc_discover connect
 assert_success "connect with global-scope config should succeed"
-assert_contains "$STDOUT" ".cursor/mcp.json"
+# On Windows the printed path uses backslashes (.cursor\mcp.json); normalize
+# both directions so the assertion works on POSIX and Git Bash.
+normalized_stdout="${STDOUT//\\//}"
+assert_contains "$normalized_stdout" ".cursor/mcp.json"
 assert_contains "$STDOUT" "@discover-global"
 test_pass
 

--- a/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
+++ b/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
@@ -52,9 +52,13 @@ tmp_file="$TEST_TMP/sessions.json.$$"
 
 # Save bad headers to the keychain used by restartBridge on auto-reconnect
 # (headers are loaded from the keychain, not sessions.json, on restart).
+# Use a native path for require() — on Windows Node treats a leading "/" as the
+# current drive root, so "/d/a/.../keychain.js" resolves to "D:\d\a\..." (wrong).
+NATIVE_PROJECT_ROOT="$(to_native_path "$PROJECT_ROOT")"
+NATIVE_MCPC_HOME="$(to_native_path "$MCPC_HOME_DIR")"
 node -e "
-  process.env.MCPC_HOME_DIR = '$MCPC_HOME_DIR';
-  const { storeKeychainSessionHeaders } = require('$PROJECT_ROOT/dist/lib/auth/keychain.js');
+  process.env.MCPC_HOME_DIR = '$NATIVE_MCPC_HOME';
+  const { storeKeychainSessionHeaders } = require('$NATIVE_PROJECT_ROOT/dist/lib/auth/keychain.js');
   storeKeychainSessionHeaders('$SESSION', {
     'X-Test': 'true',
     'Authorization': 'InvalidScheme not-a-bearer-token'


### PR DESCRIPTION
## Summary
This PR adds resilient file renaming to handle transient file lock errors on Windows, where antivirus scanners and other processes can briefly lock files during write operations.

## Key Changes
- **New `atomicRename()` utility function** in `src/lib/utils.ts`: Wraps `fs.rename()` with retry logic that handles transient Windows errors (EPERM, EBUSY, EACCES). On Windows, it retries up to 10 times with exponential backoff (20ms × attempt); on other platforms it attempts once.

- **Updated file save operations** to use `atomicRename()`:
  - `src/lib/sessions.ts`: Session data persistence
  - `src/lib/auth/profiles.ts`: Auth profile persistence
  - `src/lib/wallets.ts`: Wallet data persistence

- **Test improvements**:
  - `test/e2e/suites/sessions/unauthorized-auto-detect.test.sh`: Fixed Node.js `require()` path handling on Windows by converting paths to native format (prevents misinterpretation of leading "/" as drive root)
  - `test/e2e/suites/basic/connect-discover.test.sh`: Normalized path separators in assertions to handle Windows backslashes

## Implementation Details
The retry mechanism uses exponential backoff (20ms × attempt number) to give transient file locks time to clear without overwhelming the system. The implementation distinguishes between transient errors (which are retried) and permanent errors (which are thrown immediately). This approach is particularly important for the sessions.json file, which may be accessed by multiple mcpc bridge instances and antivirus software simultaneously.

https://claude.ai/code/session_019cD1cFa3bDFeh5YMJ7iGx5