### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Lint
         run: pnpm run lint
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Build
         run: pnpm run build
@@ -76,7 +76,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Build
         run: pnpm run build
@@ -48,7 +48,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm and dependencies
-        uses: apify/workflows/pnpm-install@v0.41.1
+        uses: apify/actions/pnpm-install@v1.0.0
 
       - name: Lint
         run: pnpm run lint


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.