### PR TITLE
chore: Update actions from `apify/actions` [internal]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Lint
         run: pnpm run lint
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Build
         run: pnpm run build
@@ -76,7 +76,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Lint
         run: pnpm run lint
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Build
         run: pnpm run build
@@ -76,7 +76,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Lint
         run: pnpm run lint
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Build
         run: pnpm run build
@@ -76,7 +76,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Build
         run: pnpm run build
@@ -48,7 +48,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Build
         run: pnpm run build
@@ -48,7 +48,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 24
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Build
         run: pnpm run build
@@ -48,7 +48,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm and dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
 
       - name: Lint
         run: pnpm run lint


### PR DESCRIPTION
There was an issue with the `v1.0.0` version of some of the actions from `apify/actions` (a NPM dependency was not present), I've released an updated version which fixes it.