### PR TITLE
Add Linux E2E tests and improve release notes

### DIFF
--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -1,0 +1,56 @@
+name: E2E Linux
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  e2e-linux-node:
+    name: E2E tests (Linux, Node.js)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm and dependencies
+        uses: apify/actions/pnpm-install@v1.1.2
+
+      - name: Build
+        run: pnpm run build
+
+      - name: E2E tests
+        # Run without gnome-keyring: @napi-rs/keyring fails fast when no D-Bus secret
+        # service is available, and keychain.ts automatically falls back to encrypted
+        # file storage (~/.mcpc/credentials.json, mode 0600).  The keychain code paths
+        # are covered by unit tests; e2e tests only need credentials to work, not a
+        # specific storage backend.
+        run: ./test/e2e/run.sh --no-build --parallel 6
+
+  e2e-linux-bun:
+    name: E2E tests (Linux, Bun)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install pnpm and dependencies
+        uses: apify/actions/pnpm-install@v1.1.2
+
+      - name: Build
+        run: pnpm run build
+
+      - name: E2E tests
+        run: ./test/e2e/run.sh --no-build --runtime bun --parallel 4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
     if: ${{ !inputs.skip-windows-e2e }}
     uses: ./.github/workflows/e2e-windows.yml
 
+  e2e-linux:
+    # Re-run the full Linux E2E matrix on the exact commit being released.
+    # ci.yml only runs on push/PR, so a manually-dispatched release (especially
+    # a pre-release from a feature branch) is not otherwise guaranteed to have
+    # had Linux E2E executed against this SHA.
+    uses: ./.github/workflows/e2e-linux.yml
+
   conformance:
     # Gate releases on MCP spec conformance so we never publish a version
     # that regresses against the reference conformance suite.
@@ -46,13 +53,15 @@ jobs:
   release:
     name: Publish ${{ inputs.type }}
     runs-on: ubuntu-latest
-    needs: [e2e-windows, conformance]
+    needs: [e2e-windows, e2e-linux, conformance]
     # Release must be from main; pre-release can be from any branch.
     # Allow the e2e-windows dependency to be either successful or skipped
-    # (when the user opts out via skip-windows-e2e). Conformance must pass.
+    # (when the user opts out via skip-windows-e2e). Linux E2E and conformance
+    # must pass.
     if: |
       always() &&
       (needs.e2e-windows.result == 'success' || needs.e2e-windows.result == 'skipped') &&
+      needs.e2e-linux.result == 'success' &&
       needs.conformance.result == 'success' &&
       (inputs.type == 'pre-release' || github.ref == 'refs/heads/main')
 
@@ -155,8 +164,12 @@ jobs:
           fi
 
           NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           PKG_NAME=$(node -p "require('./package.json').name")
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "package-name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+          # Print install instructions to the job logs AND the run summary so
+          # they are visible both while the run is in progress and on the run
+          # summary tab afterwards.
           {
             echo "### Pre-release version: \`$NEW_VERSION\`"
             echo ""
@@ -166,7 +179,7 @@ jobs:
             echo "# or"
             echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
             echo "\`\`\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Publish pre-release to npm
         if: inputs.type == 'pre-release'
@@ -182,6 +195,17 @@ jobs:
           name: v${{ steps.prerelease.outputs.version }}
           prerelease: true
           generate_release_notes: true
+          # Append install instructions to the auto-generated "What's Changed"
+          # so the release page shows users how to install this version.
+          append_body: true
+          body: |
+            ## Install
+
+            ```bash
+            npm install -g ${{ steps.prerelease.outputs.package-name }}@${{ steps.prerelease.outputs.version }}
+            # or
+            bun install -g ${{ steps.prerelease.outputs.package-name }}@${{ steps.prerelease.outputs.version }}
+            ```
           target_commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
@@ -197,8 +221,12 @@ jobs:
           pnpm version "${{ inputs.version }}" --no-git-tag-version
 
           NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           PKG_NAME=$(node -p "require('./package.json').name")
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "package-name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+          # Print install instructions to the job logs AND the run summary so
+          # they are visible both while the run is in progress and on the run
+          # summary tab afterwards.
           {
             echo "### Release version: \`$NEW_VERSION\`"
             echo ""
@@ -208,7 +236,7 @@ jobs:
             echo "# or"
             echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
             echo "\`\`\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Update CHANGELOG.md
         if: inputs.type == 'release'
@@ -250,5 +278,16 @@ jobs:
           tag_name: v${{ steps.release.outputs.version }}
           name: v${{ steps.release.outputs.version }}
           generate_release_notes: true
+          # Append install instructions to the auto-generated "What's Changed"
+          # so the release page shows users how to install this version.
+          append_body: true
+          body: |
+            ## Install
+
+            ```bash
+            npm install -g ${{ steps.release.outputs.package-name }}@${{ steps.release.outputs.version }}
+            # or
+            bun install -g ${{ steps.release.outputs.package-name }}@${{ steps.release.outputs.version }}
+            ```
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR adds comprehensive end-to-end testing for Linux environments and enhances release documentation by including installation instructions on GitHub release pages.

## Key Changes

- **New Linux E2E workflow** (`e2e-linux.yml`):
  - Tests on Node.js 24 with parallel execution (6 workers)
  - Tests on Bun runtime with parallel execution (4 workers)
  - Runs without gnome-keyring to test encrypted file storage fallback
  - Integrated into the release workflow to ensure Linux compatibility before publishing

- **Enhanced release workflow**:
  - Added `e2e-linux` job as a required dependency for releases
  - Updated release condition to require successful Linux E2E execution
  - Added installation instructions to both pre-release and stable release GitHub release pages
  - Instructions include both npm and Bun installation methods
  - Output package name to job outputs for reuse in release body

- **Improved release documentation**:
  - Install instructions now appear on the release page itself (via `append_body`)
  - Instructions printed to both job logs and run summary for visibility during execution
  - Used `tee` to output to both stdout and GitHub summary simultaneously

## Implementation Details

- Linux E2E tests run in parallel to reduce CI time while maintaining coverage
- Pre-release and stable release flows both include installation instructions
- Package name is captured as a job output to avoid hardcoding in release body templates
- Release condition uses `always()` with explicit result checks to handle optional Windows E2E while requiring Linux E2E

https://claude.ai/code/session_01KHm3opxBjDudVG9jr5sSTq