### PR TITLE
Suppress structuredContent when visible Content is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stdio (command-based) config entries are now skipped by default when connecting from a config file (`mcpc connect <file>`). Pass `--stdio` to include them. Single-entry connects (`mcpc connect file:entry @session`) are not affected.
 - **Breaking:** `mcpc connect --json` now always returns an array of `InitializeResult` objects (extended with `toolNames` and `_mcpc` metadata), regardless of whether you connect a single server, a config file, or auto-discover all configs. Skipped/failed entries carry `_mcpc.status` (`created` | `active` | `failed` | `skipped`) and `_mcpc.skipReason` / `_mcpc.error`. The previous wrapper-object shapes (`{configFile, results, skipped}` and `{discovered, results, skipped}`) have been removed.
 - `tools-call --task` now prints the task ID and recovery commands when interrupted with Ctrl+C, so you can fetch or cancel the server-side task later
+- Human-mode `tools-call` / `tasks-result` output no longer prints the **Structured content** section when **Content** already has at least one visible block. The JSON dump was redundant verbose output (especially for LLMs) whenever a server returned both. The section is still shown when `content` is empty or contains only a JSON-dump duplicate of `structuredContent`; use `--json` to always get the full payload
 
 ### Fixed
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1136,7 +1136,10 @@ function findDuplicateTextBlocks(
  * Sections (each printed only when present):
  * 1. **Content:** — each content block rendered per its type (text blocks
  *    that duplicate `structuredContent` are omitted)
- * 2. **Structured content:** — `structuredContent` as syntax-highlighted JSON
+ * 2. **Structured content:** — `structuredContent` as syntax-highlighted JSON,
+ *    shown only when there is no visible Content (otherwise it duplicates
+ *    information already present and adds noise for LLM consumers; use
+ *    `--json` to always get the full payload)
  * 3. **Metadata:** — `_meta` as syntax-highlighted JSON
  */
 export function formatCallToolResultHuman(result: CallToolResult): string {
@@ -1151,20 +1154,20 @@ export function formatCallToolResultHuman(result: CallToolResult): string {
     skipIndices = findDuplicateTextBlocks(content, sc);
   }
 
+  const visibleContent = content?.filter((_, i) => !skipIndices.has(i)) ?? [];
+
   // Content section — skip duplicate text blocks
-  if (content && content.length > 0) {
-    const visible = content.filter((_, i) => !skipIndices.has(i));
-    if (visible.length > 0) {
-      lines.push(chalk.bold('Content:'));
-      for (let i = 0; i < visible.length; i++) {
-        if (i > 0) lines.push('');
-        formatContentBlock(visible[i] as ContentBlock, lines);
-      }
+  if (visibleContent.length > 0) {
+    lines.push(chalk.bold('Content:'));
+    for (let i = 0; i < visibleContent.length; i++) {
+      if (i > 0) lines.push('');
+      formatContentBlock(visibleContent[i] as ContentBlock, lines);
     }
   }
 
-  // Structured content section — syntax-highlighted JSON
-  if (hasStructuredContent) {
+  // Structured content section — only when Content is empty, to avoid
+  // redundant verbose output for LLMs. Available via `--json` if needed.
+  if (hasStructuredContent && visibleContent.length === 0) {
     if (lines.length > 0) lines.push('');
     lines.push(chalk.bold('Structured content:'));
     const scJson = JSON.stringify(sc, null, 2);

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -1788,15 +1788,28 @@ describe('formatCallToolResultHuman', () => {
     expect(output).not.toContain('Metadata');
   });
 
-  it('should show structuredContent as JSON when present', () => {
+  it('should show structuredContent as JSON when content is empty', () => {
     const result = {
-      content: [{ type: 'text' as const, text: 'data' }],
+      content: [],
       structuredContent: { key: 'value' },
     };
     const output = formatCallToolResultHuman(result);
     expect(output).toContain('Structured content:');
     expect(output).toContain('"key"');
     expect(output).toContain('"value"');
+  });
+
+  it('should skip structuredContent when visible Content is present', () => {
+    const result = {
+      content: [{ type: 'text' as const, text: 'data' }],
+      structuredContent: { key: 'value' },
+    };
+    const output = formatCallToolResultHuman(result);
+    // Content already conveys the result — Structured content is redundant
+    // verbose output and is suppressed (use --json for the full payload).
+    expect(output).toContain('Content:');
+    expect(output).toContain('data');
+    expect(output).not.toContain('Structured content');
   });
 
   it('should not show structuredContent section when empty', () => {
@@ -1832,7 +1845,7 @@ describe('formatCallToolResultHuman', () => {
     expect(output).toContain('Structured content:');
   });
 
-  it('should keep non-matching text blocks alongside structuredContent', () => {
+  it('should keep non-matching text blocks and suppress structuredContent', () => {
     const result = {
       content: [{ type: 'text' as const, text: 'Human-readable summary' }],
       structuredContent: { results: [1, 2, 3] },
@@ -1840,8 +1853,7 @@ describe('formatCallToolResultHuman', () => {
     const output = formatCallToolResultHuman(result);
     expect(output).toContain('Content:');
     expect(output).toContain('Human-readable summary');
-    expect(output).toContain('Structured content:');
-    expect(output).toContain('"results"');
+    expect(output).not.toContain('Structured content');
   });
 
   it('should show structuredContent when there are no content blocks', () => {
@@ -1865,10 +1877,11 @@ describe('formatCallToolResultHuman', () => {
       structuredContent: sc,
     };
     const output = formatCallToolResultHuman(result);
-    // The first text block (non-matching) is kept; the JSON duplicate is omitted
+    // The first text block (non-matching) is kept; the JSON duplicate is omitted.
+    // Since visible Content remains, Structured content is suppressed too.
     expect(output).toContain('Content:');
     expect(output).toContain('Summary');
-    expect(output).toContain('Structured content:');
+    expect(output).not.toContain('Structured content');
   });
 
   it('should format resource_link content blocks', () => {
@@ -1948,7 +1961,7 @@ describe('formatCallToolResultHuman', () => {
     expect(output).toContain('(no content)');
   });
 
-  it('should show all sections in order: content, structured content, metadata', () => {
+  it('should show Content and Metadata (and suppress structuredContent) when content is non-empty', () => {
     const result = {
       _meta: { cost: 0.01 },
       content: [
@@ -1963,17 +1976,33 @@ describe('formatCallToolResultHuman', () => {
     };
     const output = formatCallToolResultHuman(result);
 
-    // All sections present
     expect(output).toContain('Content:');
     expect(output).toContain('Some output');
     expect(output).toContain('Resource link');
+    expect(output).toContain('Metadata:');
+    expect(output).toContain('"cost"');
+    // Structured content is redundant when Content already conveys the result
+    expect(output).not.toContain('Structured content');
+
+    // Correct ordering: Content → Metadata
+    expect(output.indexOf('Content:')).toBeLessThan(output.indexOf('Metadata:'));
+  });
+
+  it('should show Structured content and Metadata when content is empty', () => {
+    const result = {
+      _meta: { cost: 0.01 },
+      content: [],
+      structuredContent: { parsed: true },
+    };
+    const output = formatCallToolResultHuman(result);
+
+    expect(output).not.toContain('Content:');
     expect(output).toContain('Structured content:');
     expect(output).toContain('"parsed"');
     expect(output).toContain('Metadata:');
     expect(output).toContain('"cost"');
 
-    // Correct ordering: Content → Structured content → Metadata
-    expect(output.indexOf('Content:')).toBeLessThan(output.indexOf('Structured content:'));
+    // Correct ordering: Structured content → Metadata
     expect(output.indexOf('Structured content:')).toBeLessThan(output.indexOf('Metadata:'));
   });
 });


### PR DESCRIPTION
## Summary

Refines the human-readable output formatting for tool call results to avoid redundant information. When a tool result contains both `content` (with visible text blocks) and `structuredContent`, the structured content is now suppressed since it duplicates information already conveyed by the content blocks. The full payload remains available via `--json` mode.

## Changes

- **Output logic**: Modified `formatCallToolResultHuman()` to only display `structuredContent` when there is no visible `content`. This reduces noise in human-readable output while preserving all information in JSON mode.

- **Test updates**: Updated and added test cases to reflect the new behavior:
  - `structuredContent` is shown only when `content` is empty
  - `structuredContent` is suppressed when visible content blocks are present
  - Verified correct section ordering: Content → Metadata (when content present) or Structured content → Metadata (when content empty)

- **Documentation**: Updated JSDoc comments in `output.ts` to clarify that `structuredContent` is shown only when there is no visible Content, and that the full payload is available via `--json`.

## Implementation Details

- Introduced `visibleContent` variable to track content blocks after filtering out duplicates, making the logic clearer and more maintainable
- The suppression applies consistently: any visible content (even a single text block) causes `structuredContent` to be hidden
- This aligns with the design principle of avoiding unnecessary verbose output for LLM consumers while maintaining full transparency in structured output modes

https://claude.ai/code/session_01V9qveFdBMjXQAb1wcZnE9b