### PR TITLE
Simplify architecture diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ wiring up dozens of MCP functions. Just one `Bash()` tool, and `mcpc` handles th
 
 ```
 
-  ┌──────────┐         Bash()         ┌──────────┐           MCP          ┌────────────┐
-  │ AI agent │  ────────────────────► │   mcpc   │  ────────────────────► │ MCP server │
-  └──────────┘                        └──────────┘    Sessions, OAuth,    └────────────┘
-                                                      Tools, Resources,
-                                                      Prompts, Tasks,
-                                                      x402, ...
+  ┌──────────┐  Bash()  ┌──────┐   MCP   ┌────────────┐
+  │ AI agent │ ───────► │ mcpc │ ──────► │ MCP server │
+  └──────────┘          └──────┘         └────────────┘
+                                  Sessions, OAuth, Tools,
+                                  Resources, Prompts,
+                                  Tasks, x402, ...
 ```
 
 CLI is the perfect _local_ interface between agents and MCP, while MCP remains the

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ wiring up dozens of MCP functions. Just one `Bash()` tool, and `mcpc` handles th
 
 ```
 
-  ┌──────────┐  Bash()  ┌──────┐   MCP   ┌────────────┐
-  │ AI agent │ ───────► │ mcpc │ ──────► │ MCP server │
-  └──────────┘          └──────┘         └────────────┘
-                                  Sessions, OAuth, Tools,
-                                  Resources, Prompts,
-                                  Tasks, x402, ...
+ ┌──────────┐   Bash()   ┌────────┐    MCP    ┌────────────┐
+ │ AI agent │ ─────────► │  mcpc  │ ────────► │ MCP server │
+ └──────────┘            └────────┘           └────────────┘
+                                     Sessions, OAuth, Tools,
+                                     Resources, Prompts,
+                                     Tasks, x402, ...
 ```
 
 CLI is the perfect _local_ interface between agents and MCP, while MCP remains the


### PR DESCRIPTION
## Summary
Simplified the ASCII architecture diagram in the README to make it more concise and easier to read while maintaining the same conceptual information.

## Changes
- Reduced diagram width and complexity by removing excessive spacing and alignment characters
- Condensed the flow arrows from multi-line to single-line representation
- Moved the feature list (Sessions, OAuth, Tools, Resources, Prompts, Tasks, x402) below the diagram for better readability
- Maintained all original information while improving visual clarity

## Details
The diagram now uses a more compact layout that is easier to parse at a glance, while still clearly showing the relationship between the AI agent, `mcpc`, and the MCP server. This improves the README's presentation without changing any technical content or documentation.

https://claude.ai/code/session_013Fze4keWkHv52j43eoS97b