### PR TITLE
Add macOS E2E tests to release workflow

### DIFF
--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -1,0 +1,51 @@
+name: E2E macOS
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  e2e-macos-node:
+    name: E2E tests (macOS, Node.js)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm and dependencies
+        uses: apify/actions/pnpm-install@v1.1.2
+
+      - name: Build
+        run: pnpm run build
+
+      - name: E2E tests
+        run: ./test/e2e/run.sh --no-build --parallel 4
+
+  e2e-macos-bun:
+    name: E2E tests (macOS, Bun)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install pnpm and dependencies
+        uses: apify/actions/pnpm-install@v1.1.2
+
+      - name: Build
+        run: pnpm run build
+
+      - name: E2E tests
+        run: ./test/e2e/run.sh --no-build --runtime bun --parallel 4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip-macos-e2e:
+        description: 'Skip macOS E2E tests (they take a long time)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -37,6 +42,10 @@ jobs:
   e2e-windows:
     if: ${{ !inputs.skip-windows-e2e }}
     uses: ./.github/workflows/e2e-windows.yml
+
+  e2e-macos:
+    if: ${{ !inputs.skip-macos-e2e }}
+    uses: ./.github/workflows/e2e-macos.yml
 
   e2e-linux:
     # Re-run the full Linux E2E matrix on the exact commit being released.
@@ -53,14 +62,15 @@ jobs:
   release:
     name: Publish ${{ inputs.type }}
     runs-on: ubuntu-latest
-    needs: [e2e-windows, e2e-linux, conformance]
+    needs: [e2e-windows, e2e-macos, e2e-linux, conformance]
     # Release must be from main; pre-release can be from any branch.
-    # Allow the e2e-windows dependency to be either successful or skipped
-    # (when the user opts out via skip-windows-e2e). Linux E2E and conformance
-    # must pass.
+    # Allow the e2e-windows and e2e-macos dependencies to be either successful
+    # or skipped (when the user opts out via skip-windows-e2e / skip-macos-e2e).
+    # Linux E2E and conformance must pass.
     if: |
       always() &&
       (needs.e2e-windows.result == 'success' || needs.e2e-windows.result == 'skipped') &&
+      (needs.e2e-macos.result == 'success' || needs.e2e-macos.result == 'skipped') &&
       needs.e2e-linux.result == 'success' &&
       needs.conformance.result == 'success' &&
       (inputs.type == 'pre-release' || github.ref == 'refs/heads/main')

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -16,6 +16,7 @@ VERSION_TYPE="patch"
 RELEASE_TYPE="release"
 RELEASE_BRANCH="main"
 SKIP_WINDOWS_E2E="false"
+SKIP_MACOS_E2E="false"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -32,8 +33,12 @@ while [[ $# -gt 0 ]]; do
       SKIP_WINDOWS_E2E="true"
       shift
       ;;
+    --skip-macos-e2e)
+      SKIP_MACOS_E2E="true"
+      shift
+      ;;
     -h|--help)
-      echo "Usage: ./scripts/publish.sh [major|minor|patch] [--pre-release] [--skip-windows-e2e]"
+      echo "Usage: ./scripts/publish.sh [major|minor|patch] [--pre-release] [--skip-windows-e2e] [--skip-macos-e2e]"
       echo ""
       echo "Triggers the release.yml GitHub Actions workflow."
       echo ""
@@ -41,6 +46,7 @@ while [[ $# -gt 0 ]]; do
       echo "  major|minor|patch   Version bump type (default: patch)"
       echo "  --pre-release       Create a pre-release (beta) instead of a stable release"
       echo "  --skip-windows-e2e  Skip the slow Windows E2E tests (included by default)"
+      echo "  --skip-macos-e2e    Skip the slow macOS E2E tests (included by default)"
       echo ""
       echo "Examples:"
       echo "  npm run release                      # patch release"
@@ -52,7 +58,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       echo -e "${RED}Unknown option: $1${NC}"
-      echo "Usage: ./scripts/publish.sh [major|minor|patch] [--pre-release] [--skip-windows-e2e]"
+      echo "Usage: ./scripts/publish.sh [major|minor|patch] [--pre-release] [--skip-windows-e2e] [--skip-macos-e2e]"
       exit 1
       ;;
   esac
@@ -115,7 +121,8 @@ gh workflow run release.yml \
   --ref "$BRANCH" \
   -f type="$RELEASE_TYPE" \
   -f version="$VERSION_TYPE" \
-  -f skip-windows-e2e="$SKIP_WINDOWS_E2E"
+  -f skip-windows-e2e="$SKIP_WINDOWS_E2E" \
+  -f skip-macos-e2e="$SKIP_MACOS_E2E"
 echo -e "${GREEN}✓ Workflow triggered${NC}"
 
 # Wait briefly for the run to appear, then fetch its URL


### PR DESCRIPTION
## Summary

Adds macOS end-to-end testing to the release workflow, with an option to skip these tests since they take a long time to run.

## Changes

- **New workflow file** (`.github/workflows/e2e-macos.yml`):
  - Runs E2E tests on macOS with both Node.js 24 and Bun runtimes
  - Each runtime variant runs tests in parallel with 4 workers
  - Mirrors the structure of existing Windows E2E workflow

- **Updated release workflow** (`.github/workflows/release.yml`):
  - Added `skip-macos-e2e` input parameter (defaults to `false`)
  - Integrated macOS E2E job as a dependency for the release job
  - Updated release job condition to allow macOS E2E to be skipped (like Windows E2E)
  - Updated job dependencies to include `e2e-macos`

- **Updated publish script** (`scripts/publish.sh`):
  - Added `--skip-macos-e2e` command-line flag
  - Updated help text and usage examples to document the new flag
  - Passes the flag to the GitHub Actions workflow dispatch call

## Implementation Details

The macOS E2E workflow follows the same pattern as the Windows E2E workflow:
- Tests run on `macos-latest` runner
- Both Node.js and Bun runtimes are tested in separate jobs
- Tests use the `./test/e2e/run.sh` script with `--parallel 4` for efficiency
- The release job treats macOS E2E the same as Windows E2E: it can be skipped but if run, must succeed

https://claude.ai/code/session_012F2hcjJGT4Un2sEdqeXHcH