### PR TITLE
Clarify git commit restrictions for local vs web Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -786,4 +786,4 @@ The `CHANGELOG.md` file follows [Keep a Changelog](https://keepachangelog.com/en
 
 When writing titles of sections in README and code, do not capitalize first letters (e.g. "Session management" instead of "Session Management")
 
-Never add files to git or commit yourself.
+Never add files to git or commit yourself during local development — i.e. interactive Claude Code sessions running on the user's own machine. This does not apply to Claude Code on the web (the managed remote execution environment), where committing and pushing your changes to the designated branch is part of the expected workflow.


### PR DESCRIPTION
## Summary

Updated the CLAUDE.md guidance to clarify that the restriction on adding files to git and committing applies only to local interactive Claude Code sessions, not to Claude Code on the web where committing and pushing changes is part of the expected workflow.

## Changes

- Expanded the git commit restriction note to distinguish between local development environments and the managed remote execution environment (Claude Code on the web)
- Clarified that committing and pushing changes to the designated branch is expected behavior in the web-based Claude Code environment

## Details

This change removes ambiguity in the development guidelines by explicitly stating that the "never commit yourself" rule is specific to local interactive Claude Code sessions running on the user's own machine, while acknowledging that the web-based Claude Code environment has different expectations where commits and pushes are part of the normal workflow.

https://claude.ai/code/session_01QdUs46nC48Q9senf85NSDc