### PR TITLE
Fix log file path assertion in logs test for cross-platform compatibility

### DIFF
--- a/test/e2e/suites/sessions/logs.test.sh
+++ b/test/e2e/suites/sessions/logs.test.sh
@@ -25,9 +25,6 @@ _SESSIONS_CREATED+=("$SESSION")
 run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
 assert_success "connect should succeed"
 
-LOG_DIR="$MCPC_HOME_DIR/logs"
-LOG_FILE="$LOG_DIR/bridge-${SESSION}.log"
-
 # =============================================================================
 # Error: session does not exist
 # =============================================================================
@@ -57,8 +54,13 @@ test_pass
 test_case "default logs prints header on stderr and lines on stdout"
 run_mcpc "$SESSION" logs
 assert_success
-# Header (path + tail label) goes to stderr
-assert_contains "$STDERR" "$LOG_FILE"
+# Header (path + tail label) goes to stderr. Match the log file's basename
+# rather than the full path: mcpc resolves the path from MCPC_HOME_DIR via
+# Node, which diverges from the bash-side value on Windows (MSYS rewrites
+# /tmp to a native C:\...\Temp path) and macOS (path.resolve collapses
+# TMPDIR's trailing slash). The basename uniquely identifies this session's
+# log file and is portable across platforms.
+assert_contains "$STDERR" "bridge-${SESSION}.log"
 assert_contains "$STDERR" "last 50 lines"
 # At least one log line on stdout (bridge writes a startup banner + version line)
 if [[ -z "$STDOUT" ]]; then


### PR DESCRIPTION
## Summary

Updated the `logs.test.sh` test to use basename matching instead of full path matching when asserting log file paths in stderr output. This fixes cross-platform test failures caused by path resolution differences between bash and Node.js.

## Changes

- Removed hardcoded `LOG_DIR` and `LOG_FILE` variable definitions that were only used in a single assertion
- Changed the stderr assertion from matching the full log file path (`$LOG_FILE`) to matching just the basename (`bridge-${SESSION}.log`)
- Added detailed comment explaining the rationale: Node.js `path.resolve()` behavior diverges from bash on Windows (MSYS path rewriting) and macOS (TMPDIR trailing slash handling)

## Implementation Details

The test now matches against the log file's basename rather than the full path. This approach:
- Uniquely identifies the session's log file across all platforms
- Avoids path normalization differences between bash and Node.js
- Maintains test correctness while improving portability
- Simplifies the test by removing unused variable definitions

https://claude.ai/code/session_01Kmz2RNH1irbbybSaksWiTS