### PR TITLE
Support stateless MCP connections with cache TTL and statefulness tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mcpc @<session>` now reports the negotiated MCP protocol version and whether the connection is stateful (a stdio process, or an HTTP server that assigned a session id) or stateless (an HTTP server that assigned none — the upcoming `2026-07-28` model). The same `statefulness` value is exposed under `_mcpc` in the `--json` output of `mcpc @<session>` and `mcpc connect`, and on each session in the session list. Stateless sessions are never marked `expired` on a transient `404` (they hold no session to lose).
 - `mcpc @<session> logs` command to show or follow the bridge log file. Supports `-n/--tail <n>` (default 50), `--follow` to stream new lines, and `--since <duration|iso>` (e.g. `1h`, `30m`, `2026-04-28T12:00:00Z`). Transparently spans rotated files (`.log.1` … `.log.5`) when more lines are needed. With `--json`, returns parsed `{ time, level, context?, msg }` records (continuation lines such as stack traces fold into the preceding entry's `msg`; lines that aren't standard log entries become `{ raw }`); combined with `--follow`, output is JSONL. `mcpc @<session> --json` now also exposes `_mcpc.logPath` and `_mcpc.logSize`. Error messages that previously pointed users to a raw log file path now suggest `mcpc @<session> logs` instead (#205).
 
 ### Deprecated

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -8,7 +8,7 @@
 import { initProxy, proxyFetch } from '../lib/proxy.js';
 import { createServer, type Server as NetServer, type Socket } from 'net';
 import { unlink } from 'fs/promises';
-import { createMcpClient, CreateMcpClientOptions } from '../core/index.js';
+import { createMcpClient, CreateMcpClientOptions, buildClientCapabilities } from '../core/index.js';
 import type { McpClient } from '../core/index.js';
 import type { ServerConfig, IpcMessage, LoggingLevel, X402SchemePreference } from '../lib/index.js';
 import { KEEPALIVE_INTERVAL_MS, X402_SCHEME_PREFERENCES } from '../lib/types.js';
@@ -605,17 +605,7 @@ class BridgeProcess {
     const clientConfig: CreateMcpClientOptions = {
       clientInfo: { name: 'mcpc', version: mcpcVersion },
       serverConfig,
-      capabilities: {
-        roots: { listChanged: true },
-        sampling: {},
-        tasks: {
-          list: {},
-          cancel: {},
-          requests: {
-            sampling: { createMessage: {} },
-          },
-        },
-      },
+      capabilities: buildClientCapabilities(),
       // Pass auth provider for automatic token refresh (HTTP transport only)
       ...(this.authProvider && { authProvider: this.authProvider }),
       // Pass session ID for resumption (HTTP transport only)
@@ -701,6 +691,8 @@ class BridgeProcess {
     // Detect session ID mismatch: we tried to resume but server did not return the
     // same session ID. This covers: server issued a different ID, or server did not
     // return any ID at all (e.g. session state lost). Either way the old session is gone.
+    // Guarded by `this.options.mcpSessionId`, so stateless connections (which never resume,
+    // since no session id was ever persisted) fall through without being marked expired.
     if (this.options.mcpSessionId && newMcpSessionId !== this.options.mcpSessionId) {
       logger.warn(
         `Server did not resume MCP session ` +
@@ -728,6 +720,12 @@ class BridgeProcess {
     };
     if (serverDetails.protocolVersion) {
       sessionUpdate.protocolVersion = serverDetails.protocolVersion;
+    }
+    // Persist statefulness (derived by getServerDetails from the transport + session id) so the
+    // session list can display it without an extra round-trip. stdio is always stateful; HTTP is
+    // stateful/resumable iff the server assigned a session id, else stateless (2026-07-28 model).
+    if (serverDetails.statefulness) {
+      sessionUpdate.statefulness = serverDetails.statefulness;
     }
     if (serverDetails.serverInfo) {
       sessionUpdate.serverInfo = serverDetails.serverInfo;
@@ -880,8 +878,13 @@ class BridgeProcess {
       }
     }
 
+    // Only treat a bare HTTP 404 as session expiry when this connection actually has a
+    // server-assigned session id to lose. Stateless servers (2026-07-28) issue no id, so a
+    // transient 404 there is a routing/path error, not an expired session — never mark such
+    // a session "expired" (it cannot be, and there is nothing for `restart` to recover).
+    const hadActiveSession = !!(this.options.mcpSessionId || this.client?.getMcpSessionId());
     let status: 'expired' | 'unauthorized' | null = null;
-    if (isSessionExpiredError(error.message, { hadActiveSession: true })) {
+    if (isSessionExpiredError(error.message, { hadActiveSession })) {
       logger.warn('Session appears to be expired, marking as expired and shutting down');
       status = 'expired';
     } else if (isAuthenticationError(error.message)) {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -277,6 +277,10 @@ async function buildConnectResultEntry(
           ...(options.configFile && { configFile: options.configFile }),
           ...(options.entry && { entry: options.entry }),
           status,
+          ...(serverDetails.statefulness &&
+            serverDetails.statefulness !== 'unknown' && {
+              statefulness: serverDetails.statefulness,
+            }),
         },
         ...(serverDetails.protocolVersion && { protocolVersion: serverDetails.protocolVersion }),
         ...(serverDetails.capabilities && { capabilities: serverDetails.capabilities }),
@@ -854,7 +858,7 @@ export async function showServerDetails(
 ): Promise<void> {
   await withMcpClient(target, options, async (client, context) => {
     const serverDetails = await client.getServerDetails();
-    const { serverInfo, capabilities, instructions, protocolVersion } = serverDetails;
+    const { serverInfo, capabilities, instructions, protocolVersion, statefulness } = serverDetails;
 
     // Get tools list (uses bridge cache when available, no extra server call)
     const cachedToolsResult = await client.listAllTools();
@@ -895,6 +899,7 @@ export async function showServerDetails(
               sessionName: context.sessionName,
               profileName: context.profileName,
               server,
+              ...(statefulness && statefulness !== 'unknown' && { statefulness }),
               ...(logPath && { logPath }),
               ...(logSize !== undefined && { logSize }),
             },

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1377,13 +1377,22 @@ export function formatServerDetails(
   const bullet = chalk.dim('*');
   const bt = chalk.gray('`'); // backtick
 
-  const { serverInfo, capabilities, instructions } = details;
+  const { serverInfo, capabilities, instructions, protocolVersion, statefulness } = details;
 
   // Server info
   if (serverInfo) {
     lines.push(
       chalk.bold('Server:') + ` ${serverInfo.name} (version: ${serverInfo.version || 'N/A'})`
     );
+    lines.push('');
+  }
+
+  // Protocol version + whether the connection is stateful (stateless = 2026-07-28 model,
+  // any request may hit any server instance; stateful = stdio process or HTTP session id)
+  const hasMode = statefulness !== undefined && statefulness !== 'unknown';
+  if (protocolVersion || hasMode) {
+    const mode = hasMode ? ` (${statefulness})` : '';
+    lines.push(chalk.bold('Protocol:') + ` ${protocolVersion ?? 'unknown'}${mode}`);
     lines.push('');
   }
 

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -1,0 +1,33 @@
+/**
+ * Client capabilities advertised by mcpc during connection.
+ */
+
+import type { ClientCapabilities } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Build the MCP client capabilities mcpc advertises to servers.
+ *
+ * Kept as a single source of truth so it can evolve per protocol generation:
+ * - `roots` and `sampling` (and server-side `logging`) are deprecated as of `2026-07-28`
+ *   (SEP-2577) but remain functional through at least 2027-07-28 and are still required by
+ *   legacy servers, so we keep declaring them. Servers ignore capabilities they don't
+ *   understand, so over-declaring against a newer server is harmless.
+ * - `tasks` will move into the negotiated `extensions` map (a reverse-DNS id) once the SDK
+ *   exposes the `2026-07-28` Tasks extension — this is the single place to make that switch.
+ *
+ * Capabilities are declared before the protocol version is negotiated, so this cannot
+ * branch on the server's version.
+ */
+export function buildClientCapabilities(): ClientCapabilities {
+  return {
+    roots: { listChanged: true },
+    sampling: {},
+    tasks: {
+      list: {},
+      cancel: {},
+      requests: {
+        sampling: { createMessage: {} },
+      },
+    },
+  };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,3 +11,6 @@ export * from './transports.js';
 
 // Export factory functions
 export * from './factory.js';
+
+// Export client capabilities builder
+export * from './capabilities.js';

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -34,7 +34,7 @@ function getRootCauseMessage(error: Error): string {
   }
   return current.message;
 }
-import type { IMcpClient, ServerDetails, TaskUpdate } from '../lib/types.js';
+import type { IMcpClient, ServerDetails, SessionStatefulness, TaskUpdate } from '../lib/types.js';
 import type { Task } from '@modelcontextprotocol/sdk/types.js';
 
 /**
@@ -59,6 +59,15 @@ function taskToUpdate(task: Task): TaskUpdate {
 interface TransportWithProtocolVersion extends Transport {
   protocolVersion?: string;
 }
+
+/**
+ * Fallback freshness window for the in-memory tools cache on stateless connections.
+ * Stateless servers (2026-07-28) may not push tools/list_changed (no standing stream), so the
+ * cache would otherwise go stale silently. Stateful connections rely on notification-driven
+ * invalidation and use no expiry. Phase 1 will replace this fixed value with the server's
+ * ttlMs/cacheScope hint.
+ */
+const STATELESS_TOOLS_CACHE_TTL_MS = 60_000;
 
 /**
  * Options for creating an MCP client
@@ -97,6 +106,7 @@ export class McpClient implements IMcpClient {
   private hasConnected = false;
   private requestTimeout?: number;
   private cachedTools: Tool[] | null = null;
+  private cachedToolsExpiresAt: number | null = null;
 
   constructor(clientInfo: Implementation, options: McpClientOptions = {}) {
     this.logger = options.logger || createNoOpLogger();
@@ -248,6 +258,7 @@ export class McpClient implements IMcpClient {
     if (capabilities) details.capabilities = capabilities;
     if (serverInfo) details.serverInfo = serverInfo;
     if (instructions) details.instructions = instructions;
+    details.statefulness = this.deriveStatefulness();
 
     return Promise.resolve(details);
   }
@@ -258,6 +269,22 @@ export class McpClient implements IMcpClient {
    */
   getMcpSessionId(): string | undefined {
     return this.mcpSessionId;
+  }
+
+  /**
+   * Derive whether this connection carries server-side session state.
+   * stdio transports are persistent local processes (always stateful). Streamable HTTP is
+   * stateful/resumable when the server assigned a session id, otherwise stateless (the
+   * 2026-07-28 model where any request may hit any server instance).
+   */
+  private deriveStatefulness(): SessionStatefulness {
+    if (!this.hasConnected) return 'unknown';
+    // Only the Streamable HTTP transport exposes terminateSession() (it sends an HTTP DELETE);
+    // its absence indicates a stdio transport. The method exists on the HTTP transport
+    // regardless of whether a session id was issued, so it reliably distinguishes the two.
+    const isHttpTransport = typeof this.transport?.terminateSession === 'function';
+    if (!isHttpTransport) return 'stateful';
+    return this.mcpSessionId ? 'stateful' : 'stateless';
   }
 
   /**
@@ -296,7 +323,7 @@ export class McpClient implements IMcpClient {
    * Returns cached tools if available; use refreshCache to bypass cache.
    */
   async listAllTools(options?: { refreshCache?: boolean }): Promise<ListToolsResult> {
-    if (!options?.refreshCache && this.cachedTools) {
+    if (!options?.refreshCache && this.cachedTools && !this.isToolsCacheExpired()) {
       return { tools: this.cachedTools };
     }
 
@@ -310,7 +337,15 @@ export class McpClient implements IMcpClient {
     } while (cursor);
 
     this.cachedTools = allTools;
+    // Stateless connections get a time-based expiry as a fallback for absent list_changed
+    // pushes; stateful connections keep no expiry (notifications/explicit invalidation drive it).
+    this.cachedToolsExpiresAt =
+      this.deriveStatefulness() === 'stateless' ? Date.now() + STATELESS_TOOLS_CACHE_TTL_MS : null;
     return { tools: allTools };
+  }
+
+  private isToolsCacheExpired(): boolean {
+    return this.cachedToolsExpiresAt !== null && Date.now() >= this.cachedToolsExpiresAt;
   }
 
   /**
@@ -325,6 +360,7 @@ export class McpClient implements IMcpClient {
    */
   invalidateToolsCache(): void {
     this.cachedTools = null;
+    this.cachedToolsExpiresAt = null;
   }
 
   /**
@@ -512,6 +548,17 @@ export class McpClient implements IMcpClient {
   }
 
   /**
+   * Single access point for the SDK's task API. The `2025-11-25` experimental Tasks API
+   * (`experimental.tasks`) is superseded by the `2026-07-28` Tasks extension (SEP-2663:
+   * `tasks/get` polling, `tasks/update`, returnless `tasks/cancel`, and removal of
+   * `tasks/list`). Keeping every task call funnelled through here means that migration is a
+   * change to this one accessor rather than scattered across the file.
+   */
+  private get tasksApi(): SDKClient['experimental']['tasks'] {
+    return this.client.experimental.tasks;
+  }
+
+  /**
    * Call a tool with task-augmented execution
    * Uses the SDK's experimental callToolStream which handles task creation,
    * polling, and result retrieval automatically via an AsyncGenerator.
@@ -571,11 +618,7 @@ export class McpClient implements IMcpClient {
         callParams._meta = meta;
       }
 
-      const stream = this.client.experimental.tasks.callToolStream(
-        callParams,
-        CallToolResultSchema,
-        requestOptions
-      );
+      const stream = this.tasksApi.callToolStream(callParams, CallToolResultSchema, requestOptions);
 
       let result: CallToolResult | undefined;
 
@@ -644,11 +687,10 @@ export class McpClient implements IMcpClient {
       if (meta) {
         callParams._meta = meta;
       }
-      const stream = this.client.experimental.tasks.callToolStream(
-        callParams,
-        CallToolResultSchema,
-        { ...this.getRequestOptions(), task: {} }
-      );
+      const stream = this.tasksApi.callToolStream(callParams, CallToolResultSchema, {
+        ...this.getRequestOptions(),
+        task: {},
+      });
 
       for await (const message of stream) {
         if (message.type === 'taskCreated') {
@@ -732,10 +774,7 @@ export class McpClient implements IMcpClient {
   async listTasks(cursor?: string): Promise<ListTasksResult> {
     try {
       this.logger.debug('Listing tasks...', cursor ? { cursor } : {});
-      const result = await this.client.experimental.tasks.listTasks(
-        cursor,
-        this.getRequestOptions()
-      );
+      const result = await this.tasksApi.listTasks(cursor, this.getRequestOptions());
       this.logger.debug(`Found ${result.tasks.length} tasks`);
       return result;
     } catch (error) {
@@ -752,7 +791,7 @@ export class McpClient implements IMcpClient {
   async getTask(taskId: string): Promise<GetTaskResult> {
     try {
       this.logger.debug(`Getting task: ${taskId}`);
-      const result = await this.client.experimental.tasks.getTask(taskId, this.getRequestOptions());
+      const result = await this.tasksApi.getTask(taskId, this.getRequestOptions());
       this.logger.debug(`Task ${taskId} status: ${result.status}`);
       return result;
     } catch (error) {
@@ -771,7 +810,7 @@ export class McpClient implements IMcpClient {
   async getTaskResult(taskId: string): Promise<CallToolResult> {
     try {
       this.logger.debug(`Getting task result: ${taskId}`);
-      const result = await this.client.experimental.tasks.getTaskResult(
+      const result = await this.tasksApi.getTaskResult(
         taskId,
         CallToolResultSchema,
         this.getRequestOptions()
@@ -792,10 +831,7 @@ export class McpClient implements IMcpClient {
   async cancelTask(taskId: string): Promise<CancelTaskResult> {
     try {
       this.logger.debug(`Cancelling task: ${taskId}`);
-      const result = await this.client.experimental.tasks.cancelTask(
-        taskId,
-        this.getRequestOptions()
-      );
+      const result = await this.tasksApi.cancelTask(taskId, this.getRequestOptions());
       this.logger.debug(`Task ${taskId} cancelled`);
       return result;
     } catch (error) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -124,6 +124,18 @@ export type SessionStatus =
   | 'crashed';
 
 /**
+ * Whether the MCP connection carries server-side session state.
+ * - stateful: a persistent connection — a stdio child process, or a Streamable HTTP
+ *   server that assigned a session id (legacy `initialize`, or the optional
+ *   `sessions/create` in 2026-07-28+), in which case it is resumable via `MCP-Session-Id`.
+ * - stateless: a Streamable HTTP server that assigned no session id (the `2026-07-28`
+ *   model where any request may hit any server instance). Not resumable; cannot "expire".
+ * - unknown: not yet determined (e.g. before the first successful connect).
+ * Derived at connect time from the transport and the presence of a session id.
+ */
+export type SessionStatefulness = 'stateful' | 'stateless' | 'unknown';
+
+/**
  * Notification timestamps for list change events
  * Tracks when the server last notified about changes to tools, prompts, or resources
  */
@@ -155,7 +167,8 @@ export interface SessionData {
   insecure?: boolean; // Skip TLS certificate verification
   pid?: number; // Bridge process PID
   protocolVersion?: string; // Negotiated MCP version
-  mcpSessionId?: string; // Server-assigned MCP session ID for resumption (Streamable HTTP only)
+  mcpSessionId?: string; // Server-assigned MCP session ID for resumption (stateful Streamable HTTP only)
+  statefulness?: SessionStatefulness; // Whether the connection carries server-side session state (derived at connect)
   serverInfo?: {
     name: string;
     version: string;
@@ -372,6 +385,8 @@ export interface ServerDetails {
   serverInfo?: Implementation;
   /** Server-provided instructions for the client */
   instructions?: string;
+  /** Whether the connection carries server-side session state (derived from transport + session id) */
+  statefulness?: SessionStatefulness;
 }
 
 /**

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -1057,6 +1057,46 @@ describe('formatServerDetails', () => {
     expect(output).toContain('This is the server instructions.');
   });
 
+  it('shows protocol version with the stateless mode suffix', () => {
+    const details: ServerDetails = {
+      protocolVersion: '2026-07-28',
+      capabilities: {},
+      serverInfo: { name: 'Stateless Server', version: '1.0.0' },
+      statefulness: 'stateless',
+    };
+
+    const output = formatServerDetails(details, '@s');
+
+    expect(output).toContain('Protocol: 2026-07-28 (stateless)');
+  });
+
+  it('shows protocol version with the stateful mode suffix', () => {
+    const details: ServerDetails = {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      serverInfo: { name: 'Stateful Server', version: '1.0.0' },
+      statefulness: 'stateful',
+    };
+
+    const output = formatServerDetails(details, '@s');
+
+    expect(output).toContain('Protocol: 2025-11-25 (stateful)');
+  });
+
+  it('omits the statefulness suffix when it is unknown', () => {
+    const details: ServerDetails = {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      serverInfo: { name: 'S', version: '1.0.0' },
+      statefulness: 'unknown',
+    };
+
+    const output = formatServerDetails(details, '@s');
+
+    expect(output).toContain('Protocol: 2025-11-25');
+    expect(output).not.toContain('(unknown)');
+  });
+
   it('should format server info with minimal features', () => {
     const details: ServerDetails = {
       capabilities: {},


### PR DESCRIPTION
## Summary

This PR adds support for stateless MCP connections (the 2026-07-28 model where any request may hit any server instance) by introducing connection statefulness tracking, time-based cache expiry for stateless connections, and improved session state management.

## Key Changes

- **Statefulness Detection**: Added `SessionStatefulness` type and `deriveStatefulness()` method to distinguish between:
  - `stateful`: stdio processes or HTTP servers with a session ID (resumable)
  - `stateless`: HTTP servers without a session ID (not resumable, any request may hit any instance)
  - `unknown`: not yet determined
  
- **Tools Cache TTL**: Implemented time-based expiry (`STATELESS_TOOLS_CACHE_TTL_MS = 60s`) for stateless connections as a fallback since they don't receive `tools/list_changed` push notifications. Stateful connections continue to rely on notification-driven invalidation with no expiry.

- **Client Capabilities Extraction**: Moved hardcoded capabilities into a new `buildClientCapabilities()` function in `src/core/capabilities.ts` as a single source of truth for protocol generation evolution.

- **Tasks API Accessor**: Added `tasksApi` getter to centralize access to the SDK's experimental tasks API, simplifying future migration to the 2026-07-28 Tasks extension.

- **Session State Persistence**: Updated `SessionData` to persist `statefulness` alongside `mcpSessionId` so the session list can display connection mode without extra round-trips.

- **Session Expiry Logic**: Refined session expiry detection to only treat bare HTTP 404 as expiry when the connection actually has a server-assigned session ID (stateless connections cannot expire).

- **CLI Output**: Enhanced `formatServerDetails()` to display protocol version with statefulness suffix (e.g., "2026-07-28 (stateless)"), omitting the suffix when statefulness is unknown.

- **Tests**: Added unit tests for statefulness display in server details formatting.

## Implementation Details

- Statefulness is derived at connect time from the transport type (presence of `terminateSession()` method indicates HTTP) and session ID presence
- Cache expiry check is performed before returning cached tools in `listAllTools()`
- The `cachedToolsExpiresAt` field is set when caching tools and cleared on explicit invalidation
- Session resumption logic now guards against marking stateless sessions as "expired" since they have no persistent state to lose

https://claude.ai/code/session_012C98WbuwkvUPipfaeXf5ym