### PR TITLE
Make update-readme.sh work without global mcpc install

### DIFF
--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -10,6 +10,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 README="$PROJECT_ROOT/README.md"
 
+# Make project-local dev tools (doctoc, markdown-link-check) resolvable even when
+# this script is run directly rather than via "pnpm run".
+export PATH="$PROJECT_ROOT/node_modules/.bin:$PATH"
+
+# Use the locally built CLI so this works without a global "mcpc" install.
+# bin/mcpc loads dist/cli/index.js, so the project must be built first; build it
+# if missing (the release workflow already builds, so this is usually a no-op).
+MCPC_CLI="$PROJECT_ROOT/bin/mcpc"
+if [ ! -f "$PROJECT_ROOT/dist/cli/index.js" ]; then
+  echo "Building project (dist/ not found)..."
+  (cd "$PROJECT_ROOT" && pnpm run build)
+fi
+
 # Marker that identifies the auto-generated help section
 HELP_MARKER="<!-- AUTO-GENERATED: mcpc --help -->"
 
@@ -26,7 +39,14 @@ TEMP_HELP=$(mktemp)
 TEMP_README=$(mktemp)
 
 # Get help output, remove the "Full docs:" line and trailing empty line
-mcpc --help | sed '/^Full docs:/d' | sed '${/^$/d;}' > "$TEMP_HELP"
+node "$MCPC_CLI" --help | sed '/^Full docs:/d' | sed '${/^$/d;}' > "$TEMP_HELP"
+
+# Guard against capturing empty output, which would silently wipe the README block
+if [ ! -s "$TEMP_HELP" ]; then
+  echo "ERROR: 'mcpc --help' produced no output; aborting to avoid emptying the README block." >&2
+  rm -f "$TEMP_HELP" "$TEMP_README"
+  exit 1
+fi
 
 # Use awk to replace content in the code block following the marker
 awk -v marker="$HELP_MARKER" '


### PR DESCRIPTION
## Summary

Updates the `update-readme.sh` script to work independently without requiring a global `mcpc` installation or running through `pnpm run`. This improves developer experience and makes the script more robust.

## Key Changes

- **PATH setup**: Added `node_modules/.bin` to PATH so project-local dev tools (doctoc, markdown-link-check) are resolvable when the script is run directly
- **Local CLI usage**: Changed from calling global `mcpc` command to using the locally built CLI via `node bin/mcpc`, eliminating the need for a global installation
- **Auto-build**: Added automatic project build if `dist/cli/index.js` is missing, ensuring the script works even on fresh clones
- **Safety guard**: Added validation to ensure `mcpc --help` produces output before updating the README, preventing accidental data loss if the command fails silently

## Implementation Details

The script now:
1. Prepends the local `node_modules/.bin` directory to PATH for tool resolution
2. Checks if the built CLI exists and builds the project if needed (typically a no-op in CI/release workflows)
3. Invokes the CLI via `node "$MCPC_CLI"` instead of the global `mcpc` command
4. Validates that help output is non-empty before proceeding with README updates, with clear error messaging if validation fails

https://claude.ai/code/session_014Vt5MvUcgyY6Dk8ZTqSM34