### PR TITLE
Fix bridge startup on macOS (over-long Unix socket paths) and Windows discover test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcpc connect` (with no arguments) no longer silently ignores config files it can't use. Files with an empty servers object are listed as `0 servers`, and files that fail to load — invalid JSON, a project config missing a `mcpServers`/`servers` property, or an unreadable file — are listed as `(invalid)` with the reason, instead of being dropped or misreported as `No MCP config files found`.
 - `mcpc connect` now prints config file paths so they can be copy-pasted directly: paths containing spaces (e.g. macOS `Library/Application Support/...`) are quoted instead of being split when pasted into a shell.
 - `mcpc connect` no longer fails with `socket file not created within timeout` when the bridge is slow to start (CPU-constrained machines, many parallel connects). The startup window is more generous, and a bridge that crashes on startup now reports its exit code immediately instead of stalling until the timeout
+- Sessions no longer fail to start with `Bridge process exited during startup` when the mcpc home directory (or `MCPC_HOME_DIR`) resolves to a deep path — notably macOS temp dirs like `/var/folders/...` — or when a session name is very long. The bridge's Unix socket path was exceeding the operating system limit (104 bytes on macOS, 108 on Linux); such paths now fall back to a short location under the system temp directory
 
 ## [0.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcpc connect` now prints config file paths so they can be copy-pasted directly: paths containing spaces (e.g. macOS `Library/Application Support/...`) are quoted instead of being split when pasted into a shell.
 - `mcpc connect` no longer fails with `socket file not created within timeout` when the bridge is slow to start (CPU-constrained machines, many parallel connects). The startup window is more generous, and a bridge that crashes on startup now reports its exit code immediately instead of stalling until the timeout
 - Sessions no longer fail to start with `Bridge process exited during startup` when the mcpc home directory (or `MCPC_HOME_DIR`) resolves to a deep path — notably macOS temp dirs like `/var/folders/...` — or when a session name is very long. The bridge's Unix socket path was exceeding the operating system limit (104 bytes on macOS, 108 on Linux); such paths now fall back to a short location under the system temp directory
+- `mcpc @<session> restart` (and other session startups) no longer intermittently fail with `Failed to connect to bridge: connect ECONNREFUSED` during rapid restarts. The CLI now briefly retries the first connection to a freshly started bridge while it is still (re)creating its socket
 
 ## [0.3.0] - 2026-05-20
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -8,6 +8,7 @@
 import { initProxy, proxyFetch } from '../lib/proxy.js';
 import { createServer, type Server as NetServer, type Socket } from 'net';
 import { unlink } from 'fs/promises';
+import { dirname } from 'path';
 import { createMcpClient, CreateMcpClientOptions, buildClientCapabilities } from '../core/index.js';
 import type { McpClient } from '../core/index.js';
 import type { ServerConfig, IpcMessage, LoggingLevel, X402SchemePreference } from '../lib/index.js';
@@ -15,7 +16,6 @@ import { KEEPALIVE_INTERVAL_MS, X402_SCHEME_PREFERENCES } from '../lib/types.js'
 import { createLogger, setVerbose, initFileLogger, closeFileLogger } from '../lib/index.js';
 import {
   fileExists,
-  getBridgesDir,
   getSocketPath,
   ensureDir,
   cleanupOrphanedLogFiles,
@@ -943,9 +943,12 @@ class BridgeProcess {
    * Create socket server for IPC (Unix domain socket or Windows named pipe)
    */
   private async createSocketServer(): Promise<void> {
-    // Ensure bridges directory exists (for Unix sockets; Windows named pipes don't need this)
+    // Ensure the socket's directory exists (for Unix sockets; Windows named pipes
+    // don't need this). This is normally ~/.mcpc/bridges, but getSocketPath() may
+    // relocate over-long paths to a short dir under the temp dir — create whichever
+    // one applies.
     if (process.platform !== 'win32') {
-      await ensureDir(getBridgesDir());
+      await ensureDir(dirname(this.socketPath));
 
       // Remove existing socket file if it exists (Unix only).
       // Fail on error

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -9,6 +9,7 @@ import type { OutputMode } from '../../lib/index.js';
 import {
   getMcpcHome,
   getBridgesDir,
+  getShortSocketDir,
   getLogsDir,
   fileExists,
   cleanupOrphanedLogFiles,
@@ -162,8 +163,10 @@ async function cleanAll(): Promise<CleanResult> {
   const mcpcHome = getMcpcHome();
   const bridgesDir = getBridgesDir();
   const logsDir = getLogsDir();
+  // getSocketPath() may relocate over-long socket paths here (under the temp dir).
+  const shortSocketDir = getShortSocketDir();
 
-  for (const dir of [bridgesDir, logsDir]) {
+  for (const dir of [bridgesDir, shortSocketDir, logsDir]) {
     if (await fileExists(dir)) {
       try {
         await rm(dir, { recursive: true, force: true });

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -41,6 +41,14 @@ const CONNECT_TIMEOUT = 5 * 1000;
  */
 const DEFAULT_CONNECT_RETRY_MS = 5_000;
 
+/**
+ * Delay between connect retries: a base plus random jitter, so that many clients
+ * retrying at once (e.g. parallel bridges in tests) don't wake in lockstep and
+ * hammer their sockets on the same cadence. Averages ~75ms.
+ */
+const CONNECT_RETRY_BASE_MS = 50;
+const CONNECT_RETRY_JITTER_MS = 50;
+
 // Maximum IPC buffer size (10 MB) — destroy socket if exceeded
 const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 
@@ -90,7 +98,7 @@ export class BridgeClient extends EventEmitter {
         const transient = code === 'ECONNREFUSED' || code === 'ENOENT';
         if (deadline > 0 && transient && Date.now() < deadline) {
           logger.debug(`Bridge socket not ready yet (${code}), retrying...`);
-          await sleep(75);
+          await sleep(CONNECT_RETRY_BASE_MS + Math.random() * CONNECT_RETRY_JITTER_MS);
           continue;
         }
         // Preserve an already-typed NetworkError (e.g. timeout); wrap raw socket errors.

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 import type { IpcMessage, NotificationData, TaskUpdate, X402WalletCredentials } from './types.js';
 import { createLogger } from './logger.js';
 import { NetworkError, ClientError, ServerError, AuthError } from './errors.js';
-import { generateRequestId } from './utils.js';
+import { generateRequestId, sleep } from './utils.js';
 
 const logger = createLogger('bridge-client');
 
@@ -50,14 +50,51 @@ export class BridgeClient extends EventEmitter {
   }
 
   /**
-   * Connect to the bridge socket
-   * Throws NetworkError if connection fails or times out
+   * Connect to the bridge socket.
+   *
+   * @param options.retryTimeoutMs - When set, transient failures (ECONNREFUSED /
+   *   ENOENT) are retried until this budget elapses. This covers the brief window
+   *   right after a bridge is spawned where its socket file may exist but not yet
+   *   accept connections — notably a stale socket left behind by a prior bridge
+   *   that reused the same PID, which the new bridge removes and recreates during
+   *   startup. Callers connecting to an established bridge (per-command requests)
+   *   omit it and fail fast.
+   *
+   * Throws NetworkError if connection fails or times out.
    */
-  async connect(): Promise<void> {
+  async connect(options?: { retryTimeoutMs?: number }): Promise<void> {
     if (this.socket) {
       return; // Already connected
     }
 
+    const deadline = options?.retryTimeoutMs ? Date.now() + options.retryTimeoutMs : 0;
+
+    for (;;) {
+      try {
+        await this.connectOnce();
+        return;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        const transient = code === 'ECONNREFUSED' || code === 'ENOENT';
+        if (deadline > 0 && transient && Date.now() < deadline) {
+          logger.debug(`Bridge socket not ready yet (${code}), retrying...`);
+          await sleep(75);
+          continue;
+        }
+        // Preserve an already-typed NetworkError (e.g. timeout); wrap raw socket errors.
+        if (error instanceof NetworkError) {
+          throw error;
+        }
+        throw new NetworkError(`Failed to connect to bridge: ${(error as Error).message}`);
+      }
+    }
+  }
+
+  /**
+   * A single connection attempt. Rejects with the raw socket error (preserving
+   * its `.code`) so connect() can decide whether the failure is retryable.
+   */
+  private connectOnce(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       logger.debug(`Connecting to bridge socket: ${this.socketPath}`);
 
@@ -96,7 +133,7 @@ export class BridgeClient extends EventEmitter {
         settle(() => {
           logger.debug('Socket connection error:', error.message);
           this.socket = null;
-          reject(new NetworkError(`Failed to connect to bridge: ${error.message}`));
+          reject(error);
         });
       });
     });

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -10,7 +10,9 @@
  * NOT responsible for:
  * - Bridge process and socket lifecycle (that's bridge-manager's job)
  * - Health checking (that's bridge-manager's job)
- * - Retry/restart logic (that's SessionClient's job)
+ * - Bridge restart/reconnect logic (that's SessionClient's job). connect() does
+ *   briefly retry a *not-yet-listening* socket right after a bridge spawns, but it
+ *   never restarts a bridge.
  */
 
 import { connect, type Socket } from 'net';
@@ -27,6 +29,17 @@ const REQUEST_TIMEOUT = 3 * 60 * 1000;
 
 // Timeout for initial socket connection (5 seconds)
 const CONNECT_TIMEOUT = 5 * 1000;
+
+/**
+ * Default budget for retrying transient connect failures (ECONNREFUSED/ENOENT).
+ * A freshly spawned or just-restarted bridge may not accept connections the instant
+ * its socket file appears — notably a stale socket left by a prior bridge that
+ * reused the same PID, which the new bridge removes and recreates as it starts up.
+ * Retrying briefly rides that out instead of failing the command (e.g. on a rapid
+ * `restart`). Callers connecting to an established bridge that should fail fast pass
+ * `retryTimeoutMs: 0`.
+ */
+const DEFAULT_CONNECT_RETRY_MS = 5_000;
 
 // Maximum IPC buffer size (10 MB) — destroy socket if exceeded
 const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
@@ -52,13 +65,11 @@ export class BridgeClient extends EventEmitter {
   /**
    * Connect to the bridge socket.
    *
-   * @param options.retryTimeoutMs - When set, transient failures (ECONNREFUSED /
-   *   ENOENT) are retried until this budget elapses. This covers the brief window
-   *   right after a bridge is spawned where its socket file may exist but not yet
-   *   accept connections — notably a stale socket left behind by a prior bridge
-   *   that reused the same PID, which the new bridge removes and recreates during
-   *   startup. Callers connecting to an established bridge (per-command requests)
-   *   omit it and fail fast.
+   * Transient failures (ECONNREFUSED/ENOENT) are retried for up to `retryTimeoutMs`
+   * (default {@link DEFAULT_CONNECT_RETRY_MS}) to ride out the brief window where a
+   * just-spawned bridge has created its socket file but is not yet accepting
+   * connections. Pass `retryTimeoutMs: 0` to fail fast (e.g. when connecting to an
+   * already-established bridge).
    *
    * Throws NetworkError if connection fails or times out.
    */
@@ -67,7 +78,8 @@ export class BridgeClient extends EventEmitter {
       return; // Already connected
     }
 
-    const deadline = options?.retryTimeoutMs ? Date.now() + options.retryTimeoutMs : 0;
+    const retryTimeoutMs = options?.retryTimeoutMs ?? DEFAULT_CONNECT_RETRY_MS;
+    const deadline = retryTimeoutMs > 0 ? Date.now() + retryTimeoutMs : 0;
 
     for (;;) {
       try {

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -106,16 +106,6 @@ function getBridgeExecutable(): string {
  */
 const BRIDGE_STARTUP_TIMEOUT_MS = 15_000;
 
-/**
- * How long the first connects to a freshly-spawned bridge (credential delivery,
- * health check) keep retrying transient socket errors. waitForFile() only proves
- * the socket *file* exists; a stale socket left by a prior bridge that reused this
- * PID still refuses connections (ECONNREFUSED), and the new bridge briefly removes
- * and recreates the file (ENOENT) before it listens. Retrying for a few seconds
- * waits that out instead of failing the command (e.g. on rapid `restart`).
- */
-const BRIDGE_SOCKET_READY_RETRY_MS = 5_000;
-
 export interface StartBridgeOptions {
   sessionName: string;
   serverConfig: ServerConfig;
@@ -397,7 +387,9 @@ async function sendBridgeShutdown(socketPath: string): Promise<boolean> {
     const timeout = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error('shutdown timeout')), 2000)
     );
-    await Promise.race([client.connect(), timeout]);
+    // Fail fast: this targets an already-running bridge, and we force-kill if it's
+    // unreachable — no point retrying a not-yet-listening socket here.
+    await Promise.race([client.connect({ retryTimeoutMs: 0 }), timeout]);
     client.send({ type: 'shutdown' });
     await client.close();
     logger.debug('Sent shutdown IPC message to bridge');
@@ -580,7 +572,8 @@ async function sendAuthCredentialsToBridge(
 
   const client = new BridgeClient(socketPath);
   try {
-    await client.connect({ retryTimeoutMs: BRIDGE_SOCKET_READY_RETRY_MS });
+    // connect() retries while the freshly-spawned bridge finishes (re)creating its socket.
+    await client.connect();
     client.sendAuthCredentials(credentials);
     logger.debug('Auth credentials sent to bridge successfully');
   } finally {
@@ -616,7 +609,7 @@ async function sendX402WalletToBridge(
 
   const client = new BridgeClient(socketPath);
   try {
-    await client.connect({ retryTimeoutMs: BRIDGE_SOCKET_READY_RETRY_MS });
+    await client.connect();
     client.sendX402Wallet(credentials);
     logger.debug('x402 wallet sent to bridge successfully');
   } finally {
@@ -642,9 +635,7 @@ interface BridgeHealthResult {
 async function checkBridgeHealth(socketPath: string): Promise<BridgeHealthResult> {
   const client = new BridgeClient(socketPath);
   try {
-    // Retry transient errors: a just-restarted bridge may still be (re)creating its
-    // socket when we connect (e.g. a stale socket from a PID-reused prior bridge).
-    await client.connect({ retryTimeoutMs: BRIDGE_SOCKET_READY_RETRY_MS });
+    await client.connect();
     // getServerDetails blocks until MCP client is connected, then returns info
     // If MCP connection fails, the bridge will return an error via IPC
     await client.request('getServerDetails');

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -106,6 +106,16 @@ function getBridgeExecutable(): string {
  */
 const BRIDGE_STARTUP_TIMEOUT_MS = 15_000;
 
+/**
+ * How long the first connects to a freshly-spawned bridge (credential delivery,
+ * health check) keep retrying transient socket errors. waitForFile() only proves
+ * the socket *file* exists; a stale socket left by a prior bridge that reused this
+ * PID still refuses connections (ECONNREFUSED), and the new bridge briefly removes
+ * and recreates the file (ENOENT) before it listens. Retrying for a few seconds
+ * waits that out instead of failing the command (e.g. on rapid `restart`).
+ */
+const BRIDGE_SOCKET_READY_RETRY_MS = 5_000;
+
 export interface StartBridgeOptions {
   sessionName: string;
   serverConfig: ServerConfig;
@@ -570,7 +580,7 @@ async function sendAuthCredentialsToBridge(
 
   const client = new BridgeClient(socketPath);
   try {
-    await client.connect();
+    await client.connect({ retryTimeoutMs: BRIDGE_SOCKET_READY_RETRY_MS });
     client.sendAuthCredentials(credentials);
     logger.debug('Auth credentials sent to bridge successfully');
   } finally {
@@ -606,7 +616,7 @@ async function sendX402WalletToBridge(
 
   const client = new BridgeClient(socketPath);
   try {
-    await client.connect();
+    await client.connect({ retryTimeoutMs: BRIDGE_SOCKET_READY_RETRY_MS });
     client.sendX402Wallet(credentials);
     logger.debug('x402 wallet sent to bridge successfully');
   } finally {
@@ -632,7 +642,9 @@ interface BridgeHealthResult {
 async function checkBridgeHealth(socketPath: string): Promise<BridgeHealthResult> {
   const client = new BridgeClient(socketPath);
   try {
-    await client.connect();
+    // Retry transient errors: a just-restarted bridge may still be (re)creating its
+    // socket when we connect (e.g. a stale socket from a PID-reused prior bridge).
+    await client.connect({ retryTimeoutMs: BRIDGE_SOCKET_READY_RETRY_MS });
     // getServerDetails blocks until MCP client is connected, then returns info
     // If MCP connection fails, the bridge will return an error via IPC
     await client.request('getServerDetails');

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -4,7 +4,13 @@
 
 import { readdir, unlink, stat } from 'fs/promises';
 import { join } from 'path';
-import { getLogsDir, getBridgesDir, getSocketPath, fileExists } from './utils.js';
+import {
+  getLogsDir,
+  getBridgesDir,
+  getShortSocketDir,
+  getSocketPath,
+  fileExists,
+} from './utils.js';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('cleanup');
@@ -82,7 +88,8 @@ export async function cleanupOrphanedLogFiles(
 }
 
 /**
- * Clean up orphaned socket files in the bridges directory.
+ * Clean up orphaned socket files (in the bridges directory and the short temp-dir
+ * fallback used for over-long paths; see getSocketPath).
  * With PID-based socket paths (@session.1234.sock), stale sockets can accumulate
  * when a bridge exits without cleanup (e.g. SIGKILL, crash, or orphaned background restart).
  *
@@ -104,11 +111,6 @@ export async function cleanupOrphanedSockets(
     return 0; // Windows named pipes don't leave files
   }
 
-  const bridgesDir = getBridgesDir();
-  if (!(await fileExists(bridgesDir))) {
-    return 0;
-  }
-
   // Build set of active socket paths for fast lookup
   const activeSocketPaths = new Set<string>();
   for (const [name, session] of Object.entries(activeSessions)) {
@@ -120,24 +122,31 @@ export async function cleanupOrphanedSockets(
   const cutoffTime = Date.now() - minAgeSeconds * 1000;
   let deletedCount = 0;
 
-  const files = await readdir(bridgesDir);
-  for (const file of files) {
-    if (!file.endsWith('.sock')) continue;
+  // Sockets normally live in ~/.mcpc/bridges, but getSocketPath() relocates
+  // over-long paths to a short temp dir — scan both so neither location leaks.
+  const socketDirs = [...new Set([getBridgesDir(), getShortSocketDir()])];
+  for (const socketDir of socketDirs) {
+    if (!(await fileExists(socketDir))) continue;
 
-    const filePath = join(bridgesDir, file);
+    const files = await readdir(socketDir);
+    for (const file of files) {
+      if (!file.endsWith('.sock')) continue;
 
-    // Skip sockets that belong to a known active session+PID
-    if (activeSocketPaths.has(filePath)) continue;
+      const filePath = join(socketDir, file);
 
-    try {
-      const fileStats = await stat(filePath);
-      if (fileStats.mtime.getTime() < cutoffTime) {
-        await unlink(filePath);
-        deletedCount++;
-        logger.debug(`Removed orphaned socket: ${file}`);
+      // Skip sockets that belong to a known active session+PID
+      if (activeSocketPaths.has(filePath)) continue;
+
+      try {
+        const fileStats = await stat(filePath);
+        if (fileStats.mtime.getTime() < cutoffTime) {
+          await unlink(filePath);
+          deletedCount++;
+          logger.debug(`Removed orphaned socket: ${file}`);
+        }
+      } catch {
+        // Ignore stat/unlink errors
       }
-    } catch {
-      // Ignore stat/unlink errors
     }
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@
 
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join, resolve, isAbsolute } from 'path';
 import { mkdir, access, constants, rename } from 'fs/promises';
 import { ClientError } from './errors.js';
@@ -58,9 +58,32 @@ export function getBridgesDir(): string {
 }
 
 /**
+ * Maximum usable length, in bytes, of a Unix domain socket path. The OS stores it
+ * in the fixed-size `sockaddr_un.sun_path` buffer — 104 bytes on macOS/BSD and 108
+ * on Linux, including the trailing NUL. Exceeding it makes bind()/connect() fail
+ * with ENAMETOOLONG, which on the bridge surfaces as a crash during startup.
+ */
+const MAX_UNIX_SOCKET_PATH_BYTES = process.platform === 'linux' ? 107 : 103;
+
+/**
+ * Short, collision-free directory for bridge sockets that don't fit under
+ * ~/.mcpc/bridges (see getSocketPath). It lives under the OS temp dir — which is
+ * short on every platform — and is namespaced by a hash of the home dir so that
+ * parallel mcpc instances using different MCPC_HOME_DIR values never collide.
+ */
+export function getShortSocketDir(): string {
+  const homeHash = createHash('sha256').update(getMcpcHome()).digest('hex').slice(0, 12);
+  return join(tmpdir(), `mcpc-${homeHash}`);
+}
+
+/**
  * Get the socket/pipe path for a session's bridge process.
  *
- * On Unix/macOS: Returns a Unix domain socket path in the bridges directory.
+ * On Unix/macOS: Returns a Unix domain socket path in the bridges directory, or —
+ *                when that path would exceed the OS limit (e.g. deep macOS temp
+ *                dirs like /var/folders/..., or a long session name) — a short
+ *                hashed path under the temp dir. The CLI and bridge derive the
+ *                same path deterministically from the same inputs.
  * On Windows: Returns a named pipe path with a hash of the home directory
  *             to avoid conflicts between different mcpc instances.
  *
@@ -77,8 +100,18 @@ export function getSocketPath(sessionName: string, pid: number): string {
     return `\\\\.\\pipe\\mcpc-${homeHash}-${sessionName}${suffix}`;
   }
 
-  // Unix/macOS: use socket file in bridges directory (naturally isolated per home dir)
-  return join(getBridgesDir(), `${sessionName}${suffix}.sock`);
+  // Unix/macOS: prefer a readable socket file in the bridges directory (naturally
+  // isolated per home dir).
+  const preferredPath = join(getBridgesDir(), `${sessionName}${suffix}.sock`);
+  if (Buffer.byteLength(preferredPath) <= MAX_UNIX_SOCKET_PATH_BYTES) {
+    return preferredPath;
+  }
+
+  // The preferred path is too long for the OS socket buffer. Fall back to a short,
+  // fixed-length path under the temp dir; the session name is hashed so the result
+  // stays within the limit regardless of how long the name or home dir is.
+  const nameHash = createHash('sha256').update(sessionName).digest('hex').slice(0, 16);
+  return join(getShortSocketDir(), `${nameHash}${suffix}.sock`);
 }
 
 /**

--- a/test/e2e/suites/basic/connect-discover.test.sh
+++ b/test/e2e/suites/basic/connect-discover.test.sh
@@ -346,12 +346,15 @@ run_mcpc "@discover-http" close || true
 rm -f "$FAKE_CWD/.mcp.json" "$FAKE_CWD/mcp.json" "$FAKE_HOME/.cursor/mcp.json"
 
 # A local stdio MCP server (no network) so we can make a stdio session live.
+# Convert to a native path so Windows' node can resolve it — an MSYS path like
+# /d/a/... is otherwise misread as a relative path on the current drive (#258).
+STDIO_SERVER="$(to_native_path "$PROJECT_ROOT/test/e2e/server/stdio-server.mjs")"
 cat > "$FAKE_CWD/.mcp.json" <<EOF
 {
   "mcpServers": {
     "discover-live-stdio": {
       "command": "node",
-      "args": ["$PROJECT_ROOT/test/e2e/server/stdio-server.mjs"]
+      "args": ["$STDIO_SERVER"]
     }
   }
 }

--- a/test/unit/lib/bridge-client.test.ts
+++ b/test/unit/lib/bridge-client.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for BridgeClient connection behaviour.
+ *
+ * Focused on the connect() retry path: a freshly spawned bridge may not be
+ * accepting connections yet (e.g. a stale socket left by a prior bridge that
+ * reused the same PID), and the first connect must wait that out instead of
+ * failing the command. See bridge-manager.startBridge / restartSession.
+ */
+
+import net from 'net';
+import { existsSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { BridgeClient } from '../../../src/lib/bridge-client.js';
+
+// Unix domain sockets only; Windows uses named pipes with different semantics.
+const onWindows = process.platform === 'win32';
+
+describe.skipIf(onWindows)('BridgeClient.connect retry', () => {
+  const sockets: string[] = [];
+  const servers: net.Server[] = [];
+  const clients: BridgeClient[] = [];
+
+  function sockPath(): string {
+    const p = join(tmpdir(), `mcpc-bc-test-${Math.random().toString(36).slice(2)}.sock`);
+    sockets.push(p);
+    return p;
+  }
+
+  function listen(p: string): Promise<net.Server> {
+    return new Promise((resolve) => {
+      const server = net.createServer((conn) => conn.on('error', () => {}));
+      servers.push(server);
+      server.listen(p, () => resolve(server));
+    });
+  }
+
+  afterEach(async () => {
+    for (const client of clients) await client.close().catch(() => {});
+    clients.length = 0;
+    for (const server of servers) server.close();
+    servers.length = 0;
+    for (const p of sockets) {
+      try {
+        if (existsSync(p)) unlinkSync(p);
+      } catch {
+        // ignore
+      }
+    }
+    sockets.length = 0;
+  });
+
+  it('retries transient errors until the bridge socket starts listening', async () => {
+    const p = sockPath();
+    const client = new BridgeClient(p);
+    clients.push(client);
+
+    // The "bridge" only starts accepting connections after a short delay.
+    setTimeout(() => void listen(p), 300);
+
+    await expect(client.connect({ retryTimeoutMs: 5000 })).resolves.toBeUndefined();
+  });
+
+  it('gives up with a NetworkError after the retry budget elapses', async () => {
+    const p = sockPath(); // nothing ever listens here
+    const client = new BridgeClient(p);
+    clients.push(client);
+
+    const start = Date.now();
+    await expect(client.connect({ retryTimeoutMs: 400 })).rejects.toThrow(
+      /Failed to connect to bridge/
+    );
+    // It should have spent roughly the budget retrying, not failed immediately.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(300);
+  });
+
+  it('fails fast when no retry budget is given', async () => {
+    const p = sockPath(); // nothing listens here
+    const client = new BridgeClient(p);
+    clients.push(client);
+
+    const start = Date.now();
+    await expect(client.connect()).rejects.toThrow(/Failed to connect to bridge/);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});

--- a/test/unit/lib/bridge-client.test.ts
+++ b/test/unit/lib/bridge-client.test.ts
@@ -50,16 +50,23 @@ describe.skipIf(onWindows)('BridgeClient.connect retry', () => {
     sockets.length = 0;
   });
 
-  it('retries transient errors until the bridge socket starts listening', async () => {
-    const p = sockPath();
-    const client = new BridgeClient(p);
-    clients.push(client);
+  // Generous timeout (default retry budget equals vitest's default 5s timeout) so
+  // there is headroom for CPU contention when the whole suite runs in parallel.
+  it(
+    'retries transient errors by default until the bridge socket starts listening',
+    { timeout: 20_000 },
+    async () => {
+      const p = sockPath();
+      const client = new BridgeClient(p);
+      clients.push(client);
 
-    // The "bridge" only starts accepting connections after a short delay.
-    setTimeout(() => void listen(p), 300);
+      // The "bridge" only starts accepting connections after a short delay.
+      setTimeout(() => void listen(p), 150);
 
-    await expect(client.connect({ retryTimeoutMs: 5000 })).resolves.toBeUndefined();
-  });
+      // No options: the default retry budget must ride out the not-yet-listening window.
+      await expect(client.connect()).resolves.toBeUndefined();
+    }
+  );
 
   it('gives up with a NetworkError after the retry budget elapses', async () => {
     const p = sockPath(); // nothing ever listens here
@@ -74,13 +81,17 @@ describe.skipIf(onWindows)('BridgeClient.connect retry', () => {
     expect(Date.now() - start).toBeGreaterThanOrEqual(300);
   });
 
-  it('fails fast when no retry budget is given', async () => {
+  it('fails fast when retryTimeoutMs is 0', async () => {
     const p = sockPath(); // nothing listens here
     const client = new BridgeClient(p);
     clients.push(client);
 
     const start = Date.now();
-    await expect(client.connect()).rejects.toThrow(/Failed to connect to bridge/);
-    expect(Date.now() - start).toBeLessThan(1000);
+    await expect(client.connect({ retryTimeoutMs: 0 })).rejects.toThrow(
+      /Failed to connect to bridge/
+    );
+    // Well under the 5s default retry budget — proves it did not retry. The wide
+    // margin keeps this robust under parallel-suite CPU contention.
+    expect(Date.now() - start).toBeLessThan(2500);
   });
 });

--- a/test/unit/lib/utils.test.ts
+++ b/test/unit/lib/utils.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for utility functions
  */
 
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join, isAbsolute } from 'path';
 import {
   expandHome,
@@ -10,6 +10,8 @@ import {
   getMcpcHome,
   getSessionsFilePath,
   getBridgesDir,
+  getShortSocketDir,
+  getSocketPath,
   getLogsDir,
   isValidHttpUrl,
   normalizeServerUrl,
@@ -118,6 +120,78 @@ describe('getLogsDir', () => {
   it('should return ~/.mcpc/logs/', () => {
     const dir = getLogsDir();
     expect(dir).toBe(join(homedir(), '.mcpc', 'logs'));
+  });
+});
+
+describe('getSocketPath', () => {
+  const originalEnv = process.env.MCPC_HOME_DIR;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MCPC_HOME_DIR;
+    } else {
+      process.env.MCPC_HOME_DIR = originalEnv;
+    }
+  });
+
+  // Windows uses named pipes (a different scheme); the path-length fallback is a
+  // Unix-only concern, so these assertions only apply off Windows.
+  const onWindows = process.platform === 'win32';
+
+  it.skipIf(onWindows)('uses a readable socket under the bridges dir for short paths', () => {
+    process.env.MCPC_HOME_DIR = '/tmp/mcpc-short';
+    const socketPath = getSocketPath('my-session', 12345);
+    expect(socketPath).toBe(join(getBridgesDir(), 'my-session.12345.sock'));
+  });
+
+  it.skipIf(onWindows)('relocates over-long socket paths to a short temp-dir path', () => {
+    // A deep home dir pushes the natural path past the OS sun_path limit (104 bytes
+    // on macOS, 108 on Linux) — exactly the case that crashed bridges on macOS CI.
+    process.env.MCPC_HOME_DIR = `/tmp/mcpc-${'x'.repeat(120)}`;
+    const socketPath = getSocketPath('my-session', 12345);
+
+    // Falls back under the short temp dir, not the (over-long) bridges dir.
+    expect(socketPath.startsWith(getShortSocketDir())).toBe(true);
+    expect(socketPath.startsWith(getBridgesDir())).toBe(false);
+    expect(socketPath.endsWith('.12345.sock')).toBe(true);
+
+    // The fallback must itself fit within the most restrictive limit (macOS, 103).
+    expect(Buffer.byteLength(socketPath)).toBeLessThanOrEqual(103);
+  });
+
+  it.skipIf(onWindows)('keeps the fallback bounded even for a max-length session name', () => {
+    process.env.MCPC_HOME_DIR = `/tmp/mcpc-${'x'.repeat(120)}`;
+    const socketPath = getSocketPath('s'.repeat(64), 999999);
+    expect(socketPath.startsWith(getShortSocketDir())).toBe(true);
+    expect(Buffer.byteLength(socketPath)).toBeLessThanOrEqual(103);
+  });
+
+  it.skipIf(onWindows)('derives the same path for the CLI and bridge (deterministic)', () => {
+    process.env.MCPC_HOME_DIR = `/tmp/mcpc-${'x'.repeat(120)}`;
+    expect(getSocketPath('sess', 4242)).toBe(getSocketPath('sess', 4242));
+  });
+});
+
+describe('getShortSocketDir', () => {
+  const originalEnv = process.env.MCPC_HOME_DIR;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MCPC_HOME_DIR;
+    } else {
+      process.env.MCPC_HOME_DIR = originalEnv;
+    }
+  });
+
+  it('lives under the OS temp dir and is namespaced per home dir', () => {
+    process.env.MCPC_HOME_DIR = '/tmp/home-a';
+    const dirA = getShortSocketDir();
+    process.env.MCPC_HOME_DIR = '/tmp/home-b';
+    const dirB = getShortSocketDir();
+
+    expect(dirA.startsWith(tmpdir())).toBe(true);
+    expect(dirB.startsWith(tmpdir())).toBe(true);
+    expect(dirA).not.toBe(dirB);
   });
 });
 


### PR DESCRIPTION
The bridge's Unix socket path is built under the mcpc home dir, so a deep `MCPC_HOME_DIR` (e.g. macOS `/var/folders/...` temp dirs, or a long session name) exceeded the OS `sockaddr_un` limit (104 bytes macOS, 108 Linux) and the bridge crashed on startup — breaking every session-creating E2E test on macOS.

- `getSocketPath()` falls back to a short, deterministic temp-dir path when the natural path is too long (CLI and bridge agree on it)
- Also fixes the Windows `connect-discover` test that fed an MSYS path to a stdio config

Refs #248

https://claude.ai/code/session_01DJLkPTmAfaayFiwnofxWEv