### PR TITLE
Don't quote plain Windows paths in `mcpc connect` output

### DIFF
--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1347,13 +1347,21 @@ export function formatInfo(message: string): string {
  * Paths made only of safe characters are returned unchanged; paths containing spaces
  * or other shell-significant characters are wrapped in double quotes (which work in
  * POSIX shells and Windows cmd/PowerShell for typical paths). Only the characters that
- * remain special inside POSIX double quotes are escaped — backslashes are left intact
- * so Windows paths like `C:\Users\foo bar\mcp.json` stay verbatim.
+ * remain special inside POSIX double quotes are escaped.
+ *
+ * The backslash is the path separator on Windows (safe to paste unquoted into
+ * cmd/PowerShell) but a shell escape character on POSIX, so it counts as a safe
+ * character only on Windows — a plain `C:\Users\foo\mcp.json` stays unquoted there,
+ * while `C:\Users\foo bar\mcp.json` is still quoted because of the space.
  *
  * For human-readable output only; never use it for `--json` output or actual file I/O.
  */
-export function formatPath(p: string): string {
-  if (/^[A-Za-z0-9_./:@%+,=~-]+$/.test(p)) return p;
+export function formatPath(p: string, platform: NodeJS.Platform = process.platform): string {
+  const isSafe =
+    platform === 'win32'
+      ? /^[A-Za-z0-9_./:@%+,=~\\-]+$/.test(p)
+      : /^[A-Za-z0-9_./:@%+,=~-]+$/.test(p);
+  if (isSafe) return p;
   return `"${p.replace(/(["`$])/g, '\\$&')}"`;
 }
 

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -1994,8 +1994,18 @@ describe('formatPath', () => {
     );
   });
 
-  it('preserves backslashes in Windows paths verbatim', () => {
-    expect(formatPath('C:\\Users\\foo bar\\mcp.json')).toBe('"C:\\Users\\foo bar\\mcp.json"');
+  it('leaves plain Windows paths unquoted (backslash is the separator, not special)', () => {
+    expect(formatPath('C:\\Users\\foo\\mcp.json', 'win32')).toBe('C:\\Users\\foo\\mcp.json');
+  });
+
+  it('quotes Windows paths with spaces, preserving backslashes verbatim', () => {
+    expect(formatPath('C:\\Users\\foo bar\\mcp.json', 'win32')).toBe(
+      '"C:\\Users\\foo bar\\mcp.json"'
+    );
+  });
+
+  it('quotes backslash paths on POSIX, where backslash is a shell escape character', () => {
+    expect(formatPath('/tmp/a\\b/mcp.json', 'linux')).toBe('"/tmp/a\\b/mcp.json"');
   });
 
   it('escapes characters that stay special inside double quotes', () => {


### PR DESCRIPTION
On Windows, `mcpc connect` wrapped discovered/invalid config paths in double quotes (`"D:\...\mcp.json"`) because `formatPath` treated the backslash as shell-unsafe. Backslash is the path separator on Windows (safe unquoted in cmd/PowerShell) but a shell escape character on POSIX, so it's now treated as safe only on Windows. This also fixes the `connect-discover` e2e test that was failing on Windows.

- Plain Windows paths (`C:\Users\foo\mcp.json`) render unquoted; paths with spaces stay quoted
- POSIX output is unchanged
- Added `formatPath` unit tests for both platforms

Refs #259

https://claude.ai/code/session_01UNivY6TKwgTnNX4xB6n61t