### PR TITLE
Wait for bulk-connect sessions to finish MCP handshake before reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcpc @<session>` now reports the negotiated MCP protocol version and whether the connection is stateful (a stdio process, or an HTTP server that assigned a session id) or stateless (an HTTP server that assigned none — the upcoming `2026-07-28` model). A `stateless` field is exposed under `_mcpc` in the `--json` output of `mcpc @<session>` and `mcpc connect`, and on each session in the session list: `true` when stateless, `false` when stateful, and `null` while the mode is not yet known. Stateless sessions are never marked `expired` on a transient `404` (they hold no session to lose).
 - `mcpc @<session> logs` command to show or follow the bridge log file. Supports `-n/--tail <n>` (default 50), `--follow` to stream new lines, and `--since <duration|iso>` (e.g. `1h`, `30m`, `2026-04-28T12:00:00Z`). Transparently spans rotated files (`.log.1` … `.log.5`) when more lines are needed. With `--json`, returns parsed `{ time, level, context?, msg }` records (continuation lines such as stack traces fold into the preceding entry's `msg`; lines that aren't standard log entries become `{ raw }`); combined with `--follow`, output is JSONL. `mcpc @<session> --json` now also exposes `_mcpc.logPath`. Error messages that previously pointed users to a raw log file path now suggest `mcpc @<session> logs` instead (#205).
 
+### Changed
+
+- `mcpc connect` now waits for every connection to finish before reporting status. Bulk and auto-discovery connects (`mcpc connect`, `mcpc connect <file>`) previously returned immediately with an optimistic `connecting` status in human mode; they now behave like single-server connects and `--json`, showing each server as connected or failed (bounded by `--timeout`) with a progress spinner while connecting.
+
 ### Deprecated
 
 - The `shell` command (`mcpc shell @<session>` and `mcpc @<session> shell`) is deprecated and will be removed in a future release. It is now hidden from `--help` output and prints a deprecation warning when invoked
 
 ### Fixed
 
+- `--timeout` now bounds the wait while a session connects to its server. The bridge health check that runs as a session starts previously ignored `--timeout`, so connecting to a slow or unreachable server could block for up to the 3-minute default regardless of a shorter `--timeout`.
 - `mcpc connect` (with no arguments) no longer silently ignores config files it can't use. Files with an empty servers object are listed as `0 servers`, and files that fail to load — invalid JSON, a project config missing a `mcpServers`/`servers` property, or an unreadable file — are listed as `(invalid)` with the reason, instead of being dropped or misreported as `No MCP config files found`.
 - `mcpc connect` now prints config file paths so they can be copy-pasted directly: paths containing spaces (e.g. macOS `Library/Application Support/...`) are quoted instead of being split when pasted into a shell.
 - `mcpc connect` no longer fails with `socket file not created within timeout` when the bridge is slow to start (CPU-constrained machines, many parallel connects). The startup window is more generous, and a bridge that crashes on startup now reports its exit code immediately instead of stalling until the timeout

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -61,6 +61,7 @@ import {
 } from '../../lib/index.js';
 import { getWallet } from '../../lib/wallets.js';
 import chalk from 'chalk';
+import ora from 'ora';
 import { createLogger } from '../../lib/logger.js';
 import { parseProxyArg } from '../parser.js';
 import { getBridgeLogPath } from '../../lib/log-reader.js';
@@ -546,9 +547,9 @@ export async function connectSession(
     throw error;
   }
 
-  // When skipDetails is set (bulk connect from config file), print success immediately
-  // without waiting for the bridge to complete MCP handshake. The session will auto-recover
-  // if the server is slow or unreachable; the user can check status with `mcpc @session`.
+  // When skipDetails is set (bulk connect), return as soon as the bridge is spawned, without
+  // printing server details or waiting for the MCP handshake here. The bulk caller waits for
+  // readiness afterward (bounded by --timeout) and reports each session as live or failed.
   if (options.skipDetails) {
     if (options.outputMode === 'human' && !options.quiet) {
       console.log(formatSuccess(`Session ${name} ${isReconnect ? 'reconnected' : 'created'}`));
@@ -1085,6 +1086,61 @@ type BulkConnectResult = BulkConnectEntry & {
 };
 
 /**
+ * Wait for a freshly-spawned session's bridge to finish its MCP handshake.
+ *
+ * `getServerDetails` blocks until the bridge's MCP client connects, so this resolves once the
+ * server has responded (or rejects on handshake failure / timeout). The wait is bounded by
+ * `options.timeout` (the `--timeout` value, in seconds); without it the bridge's default request
+ * timeout applies. Output is suppressed (json + hideTarget) so callers control all rendering.
+ */
+async function waitForSessionReady(
+  sessionName: string,
+  options: { verbose?: boolean; timeout?: number }
+): Promise<{ ready: true } | { ready: false; error: string }> {
+  try {
+    await withMcpClient(
+      sessionName,
+      {
+        outputMode: 'json',
+        hideTarget: true,
+        ...(options.verbose && { verbose: options.verbose }),
+        ...(options.timeout !== undefined && { timeout: options.timeout }),
+      },
+      async (client) => {
+        await client.getServerDetails();
+      }
+    );
+    return { ready: true };
+  } catch (error) {
+    return { ready: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Wait for each freshly-spawned ('created') session to finish its MCP handshake, resolving its
+ * status to a terminal state: it stays 'created' if the server responded, or becomes 'failed'
+ * (with the error) otherwise. Already-active and spawn-failed results pass through unchanged.
+ * Waits run in parallel; `onSettled` fires as each entry settles so callers can show progress.
+ */
+async function waitForBulkConnectReady(
+  results: BulkConnectResult[],
+  options: { verbose?: boolean; timeout?: number },
+  onSettled?: () => void
+): Promise<BulkConnectResult[]> {
+  return Promise.all(
+    results.map(async (r): Promise<BulkConnectResult> => {
+      try {
+        if (r.status !== 'created') return r;
+        const ready = await waitForSessionReady(r.sessionName, options);
+        return ready.ready ? r : { ...r, status: 'failed', error: ready.error };
+      } finally {
+        onSettled?.();
+      }
+    })
+  );
+}
+
+/**
  * Connect a list of entries in parallel, printing compact status badges when done.
  * Returns the per-entry results so callers can build summaries and exit codes.
  */
@@ -1114,7 +1170,7 @@ async function bulkConnectEntries(
     )
   );
 
-  const results: BulkConnectResult[] = settled.map((outcome, i) => {
+  let results: BulkConnectResult[] = settled.map((outcome, i) => {
     const base = entries[i]!;
     if (outcome.status === 'fulfilled') {
       return { ...base, status: liveSet.has(base.sessionName) ? 'active' : 'created' };
@@ -1123,6 +1179,21 @@ async function bulkConnectEntries(
     return { ...base, status: 'failed', error };
   });
 
+  // Wait for newly-spawned sessions to finish their MCP handshake before reporting status, so
+  // human output matches --json (which waits in buildBulkConnectEntries) and single-target
+  // connect. The wait is bounded by --timeout; a spinner shows live progress. JSON callers
+  // resolve readiness later, so we only do the explicit wait here for human output.
+  if (options.outputMode === 'human' && results.some((r) => r.status === 'created')) {
+    const total = results.length;
+    let done = 0;
+    const spinner = ora(`Connecting to ${total} server${total === 1 ? '' : 's'}...`).start();
+    results = await waitForBulkConnectReady(results, options, () => {
+      done += 1;
+      spinner.text = `Connecting to servers... (${done}/${total})`;
+    });
+    spinner.stop();
+  }
+
   // Display badges in human mode (callers that render their own per-entry status,
   // e.g. config discovery, pass printBadges: false to suppress this block).
   if (options.outputMode === 'human' && printBadges) {
@@ -1130,7 +1201,7 @@ async function bulkConnectEntries(
       const name = theme.cyan(r.sessionName);
       switch (r.status) {
         case 'created':
-          console.log(`  ${theme.yellow('●')} ${name} ${theme.yellow('connecting')}`);
+          console.log(`  ${theme.green('●')} ${name} ${theme.green('created')}`);
           break;
         case 'active':
           console.log(`  ${theme.green('●')} ${name} ${chalk.dim('already active')}`);
@@ -1153,26 +1224,26 @@ async function bulkConnectEntries(
 function printBulkConnectSummary(
   results: BulkConnectResult[],
   options: { outputMode: OutputMode }
-): { active: number; connecting: number; failed: number } {
+): { active: number; connected: number; failed: number } {
   const active = results.filter((r) => r.status === 'active').length;
-  const connecting = results.filter((r) => r.status === 'created').length;
+  const connected = results.filter((r) => r.status === 'created').length;
   const failed = results.filter((r) => r.status === 'failed').length;
 
   if (options.outputMode === 'human' && results.length > 1) {
     const parts: string[] = [];
+    if (connected > 0) parts.push(`${connected} connected`);
     if (active > 0) parts.push(`${active} already active`);
-    if (connecting > 0) parts.push(`${connecting} connecting`);
     if (failed > 0) parts.push(`${failed} failed`);
     const summary = parts.join(', ');
 
     if (failed === 0) {
       console.log(formatSuccess(summary));
-    } else if (active + connecting > 0) {
+    } else if (active + connected > 0) {
       console.log(formatWarning(summary));
     }
   }
 
-  return { active, connecting, failed };
+  return { active, connected, failed };
 }
 
 /**
@@ -1265,10 +1336,10 @@ export async function connectAllFromConfig(
     return;
   }
 
-  const { active, connecting, failed } = printBulkConnectSummary(results, options);
+  const { active, connected, failed } = printBulkConnectSummary(results, options);
 
   // If ALL servers failed, exit with error
-  if (active + connecting === 0 && failed > 0) {
+  if (active + connected === 0 && failed > 0) {
     throw new ClientError(`Failed to connect any servers from ${configFile}`);
   }
 }
@@ -1445,8 +1516,8 @@ export async function connectAllFromStandardConfigs(options: BulkConnectOptions)
   });
 
   // Connect all non-skipped entries (quietly) so each server's result can be shown inline
-  // next to its config entry. We don't wait for full readiness — a newly spawned session
-  // is reported optimistically as "connecting".
+  // next to its config entry. In human mode bulkConnectEntries waits for each handshake to
+  // finish (bounded by --timeout), so the inline status reflects the real result (live/failed).
   const results =
     entries.length > 0 ? await bulkConnectEntries(entries, options, { printBadges: false }) : [];
 
@@ -1606,15 +1677,28 @@ async function maybeConnectApify(
     await connectSession(APIFY_MCP_URL, APIFY_SESSION_NAME, {
       outputMode: options.outputMode,
       ...(options.verbose && { verbose: true }),
+      ...(options.timeout !== undefined && { timeout: options.timeout }),
       headers: [`Authorization: Bearer ${token}`],
       skipDetails: true,
       quiet: true,
       noProfile: true,
     });
+    // Wait for the handshake to finish (bounded by --timeout) so we report the real result,
+    // consistent with the config-server connections above.
     if (options.outputMode === 'human') {
-      console.log(
-        `  ${theme.yellow('●')} ${theme.cyan(APIFY_SESSION_NAME)} ${theme.yellow('connecting')}`
-      );
+      const ready = await waitForSessionReady(APIFY_SESSION_NAME, {
+        ...(options.verbose && { verbose: options.verbose }),
+        ...(options.timeout !== undefined && { timeout: options.timeout }),
+      });
+      if (ready.ready) {
+        console.log(
+          `  ${theme.green('●')} ${theme.cyan(APIFY_SESSION_NAME)} ${theme.green('created')}`
+        );
+      } else {
+        console.log(
+          `  ${theme.red('●')} ${theme.cyan(APIFY_SESSION_NAME)} ${theme.red('failed')}${chalk.dim(` — ${ready.error}`)}`
+        );
+      }
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1201,7 +1201,7 @@ async function bulkConnectEntries(
       const name = theme.cyan(r.sessionName);
       switch (r.status) {
         case 'created':
-          console.log(`  ${theme.green('●')} ${name} ${theme.green('created')}`);
+          console.log(`  ${theme.green('●')} ${name} ${theme.green('live')}`);
           break;
         case 'active':
           console.log(`  ${theme.green('●')} ${name} ${chalk.dim('already active')}`);
@@ -1692,7 +1692,7 @@ async function maybeConnectApify(
       });
       if (ready.ready) {
         console.log(
-          `  ${theme.green('●')} ${theme.cyan(APIFY_SESSION_NAME)} ${theme.green('created')}`
+          `  ${theme.green('●')} ${theme.cyan(APIFY_SESSION_NAME)} ${theme.green('live')}`
         );
       } else {
         console.log(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -492,8 +492,6 @@ ${chalk.bold('Auto-discovery (no server arg):')}
   .vscode/mcp.json, .kiro/settings/mcp.json, ~/.claude.json,
   ~/.codeium/windsurf/mcp_config.json, plus VS Code & Claude Desktop configs.
   Set APIFY_API_TOKEN to auto-connect mcp.apify.com as @apify.
-  Waits for every connection to finish (bounded by --timeout), then reports
-  each server as connected or failed.
 
 ${chalk.bold('Session name:')}
   Omit @session to auto-generate from the server (mcp.apify.com → @apify)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -500,9 +500,8 @@ ${chalk.bold('Session name:')}
 
 ${chalk.bold('Stdio servers (command-based, run locally):')}
   Config entries spawn the command on connect, even if the handshake
-  later fails — only connect to configs you trust. View the bridge log
-  with: mcpc <@session> logs. Bulk connects skip stdio by default;
-  pass --stdio to include them.
+  later fails — only connect to configs you trust. Bulk connects skip
+  stdio by default; pass --stdio to include them.
 ${jsonHelp(
   'Array of `InitializeResult` objects (one per session), extended with `toolNames` and `_mcpc` metadata',
   '`[{ protocolVersion?, capabilities?, serverInfo?, instructions?, toolNames?, _mcpc: { sessionName, server?, ... }]`',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -492,8 +492,8 @@ ${chalk.bold('Auto-discovery (no server arg):')}
   .vscode/mcp.json, .kiro/settings/mcp.json, ~/.claude.json,
   ~/.codeium/windsurf/mcp_config.json, plus VS Code & Claude Desktop configs.
   Set APIFY_API_TOKEN to auto-connect mcp.apify.com as @apify.
-  Without --json, returns right away without waiting for connections to
-  finish; --json waits and reports each server's details.
+  Waits for every connection to finish (bounded by --timeout), then reports
+  each server as connected or failed.
 
 ${chalk.bold('Session name:')}
   Omit @session to auto-generate from the server (mcp.apify.com → @apify)

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1366,10 +1366,10 @@ export function formatPath(p: string, platform: NodeJS.Platform = process.platfo
 }
 
 /**
- * Format an inline connection-status badge for a session — `● live`, `● created`, or
- * `● failed — <reason>`. Used to annotate each config entry with its bulk-connect result.
- * Bulk connect waits for each handshake, so a freshly-connected session shows green `● created`
- * and an already-running one shows green `● live`. Human output only.
+ * Format an inline connection-status badge for a session — `● live` or `● failed — <reason>`.
+ * Used to annotate each config entry with its bulk-connect result. Bulk connect waits for each
+ * handshake, so any connected session — freshly created or already running — shows green
+ * `● live`, matching the session list. Human output only.
  */
 export function formatConnectStatusBadge(
   status: 'active' | 'created' | 'failed',
@@ -1377,9 +1377,8 @@ export function formatConnectStatusBadge(
 ): string {
   switch (status) {
     case 'active':
-      return `${theme.green('●')} ${theme.green('live')}`;
     case 'created':
-      return `${theme.green('●')} ${theme.green('created')}`;
+      return `${theme.green('●')} ${theme.green('live')}`;
     case 'failed':
       return `${theme.red('●')} ${theme.red('failed')}${error ? chalk.dim(` — ${error}`) : ''}`;
   }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1366,9 +1366,10 @@ export function formatPath(p: string, platform: NodeJS.Platform = process.platfo
 }
 
 /**
- * Format an inline connection-status badge for a session — `● live`, `● connecting`, or
- * `● failed — <reason>`. Used to annotate each config entry with its bulk-connect result,
- * matching the session list's green `● live` state exactly. Human output only.
+ * Format an inline connection-status badge for a session — `● live`, `● created`, or
+ * `● failed — <reason>`. Used to annotate each config entry with its bulk-connect result.
+ * Bulk connect waits for each handshake, so a freshly-connected session shows green `● created`
+ * and an already-running one shows green `● live`. Human output only.
  */
 export function formatConnectStatusBadge(
   status: 'active' | 'created' | 'failed',
@@ -1378,7 +1379,7 @@ export function formatConnectStatusBadge(
     case 'active':
       return `${theme.green('●')} ${theme.green('live')}`;
     case 'created':
-      return `${theme.yellow('●')} ${theme.yellow('connecting')}`;
+      return `${theme.green('●')} ${theme.green('created')}`;
     case 'failed':
       return `${theme.red('●')} ${theme.red('failed')}${error ? chalk.dim(` — ${error}`) : ''}`;
   }

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -630,15 +630,21 @@ interface BridgeHealthResult {
  * This blocks until MCP client is connected, then returns server info
  *
  * @param socketPath - Path to bridge's Unix socket
+ * @param timeout - Optional request timeout in seconds (the `--timeout` value). Without it the
+ *   bridge client's default request timeout applies. The health check is what blocks while a
+ *   server completes (or fails) its handshake, so this is where `--timeout` must take effect.
  * @returns Health check result with error details if unhealthy
  */
-async function checkBridgeHealth(socketPath: string): Promise<BridgeHealthResult> {
+async function checkBridgeHealth(
+  socketPath: string,
+  timeout?: number
+): Promise<BridgeHealthResult> {
   const client = new BridgeClient(socketPath);
   try {
     await client.connect();
     // getServerDetails blocks until MCP client is connected, then returns info
     // If MCP connection fails, the bridge will return an error via IPC
-    await client.request('getServerDetails');
+    await client.request('getServerDetails', undefined, timeout);
     return { healthy: true };
   } catch (error) {
     // Return error details so caller can provide informative message
@@ -661,10 +667,12 @@ async function checkBridgeHealth(socketPath: string): Promise<BridgeHealthResult
  * - If bridge process dies, socket connection fails and we restart
  *
  * @param sessionName - Name of the session
+ * @param timeout - Optional request timeout in seconds (the `--timeout` value), used to bound the
+ *   health-check `getServerDetails` call so a slow/unreachable server doesn't block past it.
  * @returns The socket path of the healthy bridge
  * @throws ClientError if bridge cannot be made healthy
  */
-export async function ensureBridgeReady(sessionName: string): Promise<string> {
+export async function ensureBridgeReady(sessionName: string, timeout?: number): Promise<string> {
   const session = await getSession(sessionName);
 
   if (!session) {
@@ -693,7 +701,7 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
 
   if (processAlive && socketPath) {
     // Process alive, try getServerDetails (blocks until MCP connected)
-    const result = await checkBridgeHealth(socketPath);
+    const result = await checkBridgeHealth(socketPath, timeout);
     if (result.healthy) {
       logger.debug(`Bridge for ${sessionName} is healthy`);
       return socketPath;
@@ -729,7 +737,7 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
   const newSocketPath = getSocketPath(sessionName, newPid);
 
   // Try getServerDetails on restarted bridge (blocks until MCP connected)
-  const result = await checkBridgeHealth(newSocketPath);
+  const result = await checkBridgeHealth(newSocketPath, timeout);
   if (result.healthy) {
     await updateSession(sessionName, { status: 'active' });
     logger.debug(`Bridge for ${sessionName} passed health check`);

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -466,10 +466,17 @@ export class SessionClient extends EventEmitter implements IMcpClient {
  *
  * Uses ensureBridgeReady() to guarantee the bridge is healthy before connecting.
  * This handles all the restart logic in one place (bridge-manager).
+ *
+ * @param timeout - Optional request timeout in seconds (the `--timeout` value). It bounds the
+ *   health check inside ensureBridgeReady(), which is what blocks while the server completes its
+ *   handshake — so `--timeout` must reach it here, before setRequestTimeout() is applied below.
  */
-export async function createSessionClient(sessionName: string): Promise<SessionClient> {
+export async function createSessionClient(
+  sessionName: string,
+  timeout?: number
+): Promise<SessionClient> {
   // Ensure bridge is healthy (may restart it)
-  const socketPath = await ensureBridgeReady(sessionName);
+  const socketPath = await ensureBridgeReady(sessionName, timeout);
 
   // Connect to the healthy bridge
   const bridgeClient = new BridgeClient(socketPath);
@@ -488,7 +495,7 @@ export async function withSessionClient<T>(
   callback: (client: IMcpClient) => Promise<T>,
   options?: { timeout?: number }
 ): Promise<T> {
-  const client = await createSessionClient(sessionName);
+  const client = await createSessionClient(sessionName, options?.timeout);
 
   if (options?.timeout !== undefined) {
     client.setRequestTimeout(options.timeout);

--- a/test/e2e/suites/basic/connect-config-file.test.sh
+++ b/test/e2e/suites/basic/connect-config-file.test.sh
@@ -38,7 +38,7 @@ run_mcpc connect "$CONFIG_FILE"
 assert_success "first connect should succeed"
 assert_contains "$STDOUT" "@alpha"
 assert_contains "$STDOUT" "@bravo"
-assert_contains "$STDOUT" "connecting"
+assert_contains "$STDOUT" "created"
 
 # Verify both sessions exist with names derived from entry names
 run_mcpc --json

--- a/test/e2e/suites/basic/connect-config-file.test.sh
+++ b/test/e2e/suites/basic/connect-config-file.test.sh
@@ -38,7 +38,7 @@ run_mcpc connect "$CONFIG_FILE"
 assert_success "first connect should succeed"
 assert_contains "$STDOUT" "@alpha"
 assert_contains "$STDOUT" "@bravo"
-assert_contains "$STDOUT" "created"
+assert_contains "$STDOUT" "live"
 
 # Verify both sessions exist with names derived from entry names
 run_mcpc --json

--- a/test/e2e/suites/basic/connect-discover.test.sh
+++ b/test/e2e/suites/basic/connect-discover.test.sh
@@ -117,7 +117,7 @@ assert_success "connect with project-scope config should succeed"
 assert_contains "$STDOUT" "Found 1 MCP config file"
 assert_contains "$STDOUT" ".mcp.json"
 assert_contains "$STDOUT" "@discover-project"
-assert_contains "$STDOUT" "connecting"
+assert_contains "$STDOUT" "created"
 test_pass
 
 # =============================================================================
@@ -318,7 +318,7 @@ run_mcpc_discover connect
 assert_success "discovery with an http + skipped stdio server should succeed"
 # The connected server shows its status inline; the stdio server is marked inline.
 assert_contains "$STDOUT" "@discover-http"
-assert_contains "$STDOUT" "connecting"
+assert_contains "$STDOUT" "created"
 assert_contains "$STDOUT" "○ skipped (stdio)"
 # Plain note (not a dim "↳" hint) pointing at --stdio.
 assert_contains "$STDOUT" "To include stdio servers, run: mcpc connect --stdio"

--- a/test/e2e/suites/basic/connect-discover.test.sh
+++ b/test/e2e/suites/basic/connect-discover.test.sh
@@ -117,7 +117,7 @@ assert_success "connect with project-scope config should succeed"
 assert_contains "$STDOUT" "Found 1 MCP config file"
 assert_contains "$STDOUT" ".mcp.json"
 assert_contains "$STDOUT" "@discover-project"
-assert_contains "$STDOUT" "created"
+assert_contains "$STDOUT" "live"
 test_pass
 
 # =============================================================================
@@ -318,7 +318,7 @@ run_mcpc_discover connect
 assert_success "discovery with an http + skipped stdio server should succeed"
 # The connected server shows its status inline; the stdio server is marked inline.
 assert_contains "$STDOUT" "@discover-http"
-assert_contains "$STDOUT" "created"
+assert_contains "$STDOUT" "live"
 assert_contains "$STDOUT" "○ skipped (stdio)"
 # Plain note (not a dim "↳" hint) pointing at --stdio.
 assert_contains "$STDOUT" "To include stdio servers, run: mcpc connect --stdio"

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -2020,8 +2020,8 @@ describe('formatConnectStatusBadge', () => {
     expect(formatConnectStatusBadge('active')).not.toContain('active');
   });
 
-  it('renders connecting / failed states', () => {
-    expect(formatConnectStatusBadge('created')).toContain('connecting');
+  it('renders created / failed states', () => {
+    expect(formatConnectStatusBadge('created')).toContain('created');
     expect(formatConnectStatusBadge('failed')).toContain('failed');
   });
 

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -2020,8 +2020,9 @@ describe('formatConnectStatusBadge', () => {
     expect(formatConnectStatusBadge('active')).not.toContain('active');
   });
 
-  it('renders created / failed states', () => {
-    expect(formatConnectStatusBadge('created')).toContain('created');
+  it('renders a freshly-connected ("created") session as "live", plus the failed state', () => {
+    expect(formatConnectStatusBadge('created')).toContain('live');
+    expect(formatConnectStatusBadge('created')).not.toContain('created');
     expect(formatConnectStatusBadge('failed')).toContain('failed');
   });
 


### PR DESCRIPTION
`mcpc connect` now waits for every connection to finish before reporting status. Bulk and auto-discovery connects (`mcpc connect`, `mcpc connect <file>`) previously returned immediately in human mode with an optimistic `connecting` status; they now behave like single-target connects and `--json`, reporting each server as connected or failed.

Also fixes `--timeout` being ignored while a session connects: the bridge health check ran with no timeout, so a slow/unreachable server could block for up to the 3-minute default regardless of a shorter `--timeout`.

- Bulk/human connect waits for each handshake, shown as `● created` / `● live` / `● failed`
- A spinner shows live progress while connecting
- `--timeout` now bounds the health check in `ensureBridgeReady` (all session commands)

https://claude.ai/code/session_01WaP8ATQyAkvFcQAELdXPUP