### PR TITLE
Fix macOS+Bun E2E hang by running the bridge under the CLI's runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `mcpc connect` now waits for every connection to finish before reporting status. Bulk and auto-discovery connects (`mcpc connect`, `mcpc connect <file>`) previously returned immediately with an optimistic `connecting` status in human mode; they now behave like single-server connects and `--json`, showing each server as connected or failed (bounded by `--timeout`) with a progress spinner while connecting.
+- `--insecure` now fails with a clear error under the Bun runtime instead of being silently ineffective: Bun's `fetch` does not honor the TLS-bypass mcpc uses, so certificate verification cannot be skipped under Bun. Run mcpc with Node to use `--insecure`.
 
 ### Deprecated
 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcpc connect` no longer fails with `socket file not created within timeout` when the bridge is slow to start (CPU-constrained machines, many parallel connects). The startup window is more generous, and a bridge that crashes on startup now reports its exit code immediately instead of stalling until the timeout
 - Sessions no longer fail to start with `Bridge process exited during startup` when the mcpc home directory (or `MCPC_HOME_DIR`) resolves to a deep path — notably macOS temp dirs like `/var/folders/...` — or when a session name is very long. The bridge's Unix socket path was exceeding the operating system limit (104 bytes on macOS, 108 on Linux); such paths now fall back to a short location under the system temp directory
 - `mcpc @<session> restart` (and other session startups) no longer intermittently fail with `Failed to connect to bridge: connect ECONNREFUSED` during rapid restarts. The CLI now briefly retries the first connection to a freshly started bridge while it is still (re)creating its socket
+- Sessions no longer hang on macOS under the Bun runtime (e.g. when connecting with `--proxy-bearer-token`, or auto-reconnecting a crashed session). The bridge now runs under the same runtime as the CLI, so OS-keychain items the CLI stored are read back under the same application identity; previously a Bun CLI paired with a Node bridge produced a cross-binary keychain read, which macOS gates with an access prompt that blocks in non-interactive contexts. A Bun user also no longer needs Node installed for the bridge to start.
 
 ## [0.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `mcpc connect` now waits for every connection to finish before reporting status. Bulk and auto-discovery connects (`mcpc connect`, `mcpc connect <file>`) previously returned immediately with an optimistic `connecting` status in human mode; they now behave like single-server connects and `--json`, showing each server as connected or failed (bounded by `--timeout`) with a progress spinner while connecting.
-- `--insecure` now fails with a clear error under the Bun runtime instead of being silently ineffective: Bun's `fetch` does not honor the TLS-bypass mcpc uses, so certificate verification cannot be skipped under Bun. Run mcpc with Node to use `--insecure`.
 
 ### Deprecated
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -168,6 +168,7 @@ class BridgeProcess {
     logger.debug(`  accessToken: ${credentials.accessToken ? 'present' : 'MISSING'}`);
     logger.debug(`  clientId: ${credentials.clientId ? 'present' : 'MISSING'}`);
     logger.debug(`  headers: ${credentials.headers ? Object.keys(credentials.headers).length : 0}`);
+    logger.debug(`  proxyBearerToken: ${credentials.proxyBearerToken ? 'present' : 'absent'}`);
 
     // Set up OAuth token manager if refresh token and client ID are provided
     if (credentials.refreshToken && credentials.clientId) {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -35,7 +35,6 @@ import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
 import { OAuthProvider } from '../lib/auth/oauth-provider.js';
 import { storeKeychainOAuthTokenInfo, readKeychainOAuthTokenInfo } from '../lib/auth/keychain.js';
 import { updateAuthProfileRefreshedAt } from '../lib/auth/profiles.js';
-import { readKeychainProxyBearerToken } from '../lib/auth/keychain.js';
 import {
   LoggingMessageNotificationSchema,
   type Tool,
@@ -102,6 +101,11 @@ class BridgeProcess {
 
   // HTTP headers (received via IPC, stored in memory only)
   private headers: Record<string, string> | null = null;
+
+  // Bearer token the proxy server requires (received via IPC, stored in memory only).
+  // Read by the CLI before spawn and sent over IPC — never read from the keychain here,
+  // keeping the bridge's only keychain access on the OAuth-refresh path (see #55).
+  private proxyBearerToken: string | null = null;
 
   // x402 wallet for automatic payment signing (received via IPC, stored in memory only)
   private x402Wallet: SignerWallet | null = null;
@@ -259,6 +263,12 @@ class BridgeProcess {
         ...credentials.headers,
       };
       logger.debug(`Stored headers "${Object.keys(this.headers).join(', ')}" in memory`);
+    }
+
+    // Store the proxy bearer token if provided (used by startProxyServer)
+    if (credentials.proxyBearerToken) {
+      this.proxyBearerToken = credentials.proxyBearerToken;
+      logger.debug('Stored proxy bearer token in memory');
     }
 
     // Signal that auth credentials have been received (unblocks startup)
@@ -764,8 +774,10 @@ class BridgeProcess {
 
     const { host, port } = this.options.proxyConfig;
 
-    // Load proxy bearer token from keychain if stored
-    const bearerToken = await readKeychainProxyBearerToken(this.options.sessionName);
+    // The proxy bearer token (if any) was delivered by the CLI over IPC, not read
+    // from the keychain here — keeping bridge keychain access on the OAuth-refresh
+    // path only (see #55).
+    const bearerToken = this.proxyBearerToken;
 
     logger.info(`Starting proxy server on ${host}:${port}`);
     if (bearerToken) {

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -152,19 +152,6 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     insecure,
   } = options;
 
-  // --insecure cannot work when the bridge runs under Bun: Bun's fetch ignores
-  // undici's TLS-bypass dispatcher, so certificate verification can't be skipped.
-  // The bridge runs under the same runtime as this CLI, so fail loudly here rather
-  // than letting the flag be silently ineffective (covers connect, restart, and
-  // reconnect — every path that starts a bridge with --insecure).
-  if (insecure && typeof (process.versions as { bun?: string }).bun === 'string') {
-    throw new ClientError(
-      '--insecure is not supported under the Bun runtime: Bun does not honor the TLS-bypass ' +
-        'mcpc relies on, so TLS certificate verification cannot be skipped. Re-run mcpc with ' +
-        'Node to use --insecure, or connect to a server with a valid certificate.'
-    );
-  }
-
   logger.debug(`Launching bridge for session: ${sessionName}`);
 
   // Read all keychain values BEFORE spawning the bridge.
@@ -249,6 +236,13 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
   // a bun CLI + node bridge). Matching runtimes keeps a single keychain identity.
   // It also means a Bun user no longer needs Node on PATH for the bridge to start.
   //
+  // --insecure disables TLS certificate verification in the bridge. initProxy()'s
+  // undici dispatcher (rejectUnauthorized: false) covers Node's fetch, but Bun's
+  // fetch ignores it; NODE_TLS_REJECT_UNAUTHORIZED=0 in the bridge's environment
+  // covers Bun (and is a harmless no-op alongside the dispatcher on Node). Scoped
+  // to this one bridge process. Set via the spawn env so it is in place before the
+  // runtime initializes TLS (a post-startup assignment could be read too late).
+  //
   // stderr is dropped: piping it (to capture a tail for failure diagnostics) made
   // rapid CLI invocations destabilize the bridge — child_process pipes are
   // net.Sockets, and the close-from-parent semantics interacted badly with the
@@ -257,6 +251,7 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
   const bridgeProcess: ChildProcess = spawn(process.execPath, [bridgeExecutable, ...args], {
     detached: true,
     stdio: 'ignore',
+    ...(insecure && { env: { ...process.env, NODE_TLS_REJECT_UNAUTHORIZED: '0' } }),
   });
 
   // Reset the Windows tasklist cache so the freshly spawned PID is observable

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -151,6 +151,19 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     insecure,
   } = options;
 
+  // --insecure cannot work when the bridge runs under Bun: Bun's fetch ignores
+  // undici's TLS-bypass dispatcher, so certificate verification can't be skipped.
+  // The bridge runs under the same runtime as this CLI, so fail loudly here rather
+  // than letting the flag be silently ineffective (covers connect, restart, and
+  // reconnect — every path that starts a bridge with --insecure).
+  if (insecure && typeof (process.versions as { bun?: string }).bun === 'string') {
+    throw new ClientError(
+      '--insecure is not supported under the Bun runtime: Bun does not honor the TLS-bypass ' +
+        'mcpc relies on, so TLS certificate verification cannot be skipped. Re-run mcpc with ' +
+        'Node to use --insecure, or connect to a server with a valid certificate.'
+    );
+  }
+
   logger.debug(`Launching bridge for session: ${sessionName}`);
 
   // Read all keychain values BEFORE spawning the bridge.
@@ -218,13 +231,20 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
   logger.debug('Bridge executable:', bridgeExecutable);
   logger.debug('Bridge args:', args);
 
-  // Spawn bridge process. stderr is dropped: piping it (to capture a tail for
-  // failure diagnostics) made rapid CLI invocations destabilize the bridge —
-  // child_process pipes are net.Sockets, and the close-from-parent semantics
-  // interacted badly with the bridge's connection handling. The 15s startup
-  // window already gives the bridge time to initialize its file logger for
-  // realistic failure modes, so the per-session log file is sufficient.
-  const bridgeProcess: ChildProcess = spawn('node', [bridgeExecutable, ...args], {
+  // Spawn the bridge under the SAME runtime as the CLI (process.execPath), not a
+  // hardcoded "node". The bridge reads OS-keychain items the CLI wrote (e.g. the
+  // proxy bearer token, session headers on reconnect); macOS keychain ACLs are
+  // per-binary, so a different binary reading the item triggers a Security access
+  // prompt — which blocks forever in headless contexts (CI hung here for 6h with
+  // a bun CLI + node bridge). Matching runtimes keeps a single keychain identity.
+  // It also means a Bun user no longer needs Node on PATH for the bridge to start.
+  //
+  // stderr is dropped: piping it (to capture a tail for failure diagnostics) made
+  // rapid CLI invocations destabilize the bridge — child_process pipes are
+  // net.Sockets, and the close-from-parent semantics interacted badly with the
+  // bridge's connection handling. The 15s startup window already gives the bridge
+  // time to initialize its file logger, so the per-session log file is sufficient.
+  const bridgeProcess: ChildProcess = spawn(process.execPath, [bridgeExecutable, ...args], {
     detached: true,
     stdio: 'ignore',
   });

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -43,6 +43,7 @@ import {
   readKeychainOAuthTokenInfo,
   readKeychainOAuthClientInfo,
   readKeychainSessionHeaders,
+  readKeychainProxyBearerToken,
 } from './auth/keychain.js';
 import { getAuthProfile } from './auth/profiles.js';
 import { getWallet } from './wallets.js';
@@ -171,12 +172,20 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
   // macOS the Keychain access dialog can block a CLI for far longer than that.
   // Loading credentials here ensures the bridge timer does not race a foreground
   // password prompt — see https://github.com/apify/mcpc/issues/55.
+  // The proxy bearer token is read here (under the CLI's runtime) and delivered to
+  // the bridge via IPC, so the bridge never reads it from the keychain itself — its
+  // only keychain access stays on the sanctioned OAuth-refresh path (see #55).
+  const proxyBearerToken = proxyConfig
+    ? ((await readKeychainProxyBearerToken(sessionName)) ?? undefined)
+    : undefined;
+
   const authCredentials =
-    profileName || headers
+    profileName || headers || proxyBearerToken
       ? await loadAuthCredentials(
           serverConfig.url || serverConfig.command || '',
           profileName,
-          headers
+          headers,
+          proxyBearerToken
         )
       : null;
   const x402Credentials = x402 ? await loadX402WalletCredentials() : null;
@@ -196,11 +205,12 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
   }
 
   // Pass auth profile to bridge
-  // Use dummy placeholder also when headers are provided (no OAuth profile),
-  // so the bridge process waits for headers before connecting to server
+  // Use a dummy placeholder when headers or a proxy bearer token are provided (no
+  // OAuth profile), so the bridge waits for the IPC credentials — which also carry
+  // the proxy bearer token — before connecting and starting its proxy server.
   if (profileName) {
     args.push('--profile', profileName);
-  } else if (headers && Object.keys(headers).length > 0) {
+  } else if ((headers && Object.keys(headers).length > 0) || proxyBearerToken) {
     args.push('--profile', 'dummy');
   }
 
@@ -523,7 +533,8 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
 async function loadAuthCredentials(
   serverUrl: string,
   profileName?: string,
-  headers?: Record<string, string>
+  headers?: Record<string, string>,
+  proxyBearerToken?: string
 ): Promise<AuthCredentials> {
   // Build credentials object
   const credentials: AuthCredentials = {
@@ -565,6 +576,13 @@ async function loadAuthCredentials(
   if (headers) {
     credentials.headers = headers;
     logger.debug(`Including ${Object.keys(headers).length} headers in credentials`);
+  }
+
+  // Add the proxy bearer token if provided, so the bridge configures its proxy
+  // server's auth from the IPC credentials instead of reading the keychain.
+  if (proxyBearerToken) {
+    credentials.proxyBearerToken = proxyBearerToken;
+    logger.debug('Including proxy bearer token in credentials');
   }
 
   return credentials;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -254,6 +254,11 @@ export interface AuthCredentials {
   accessToken?: string;
   // HTTP headers (from --header flags, stored in keychain)
   headers?: Record<string, string>;
+  // Bearer token the bridge's proxy server requires (from --proxy-bearer-token).
+  // Read by the CLI before spawn and delivered via IPC so the bridge never reads it
+  // from the keychain itself — keeping the bridge's only keychain access on the
+  // sanctioned OAuth-refresh path (see #55).
+  proxyBearerToken?: string;
 }
 
 /**

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -268,6 +268,61 @@ else
 fi
 echo ""
 
+# Print the pids of all descendants of a given pid (recursively).
+# Used to locate the hung mcpc invocation under a timed-out test shell.
+_descendant_pids() {
+  local p="$1" c
+  for c in $(pgrep -P "$p" 2>/dev/null); do
+    echo "$c"
+    _descendant_pids "$c"
+  done
+}
+
+# Capture the state of a hung test's process tree, so a timeout produces an
+# actionable failure log instead of an opaque "killed". Best-effort throughout.
+# Writes to stdout; the caller redirects it to a side file (the test is still
+# running and writing to its own output.log, so we must not race it there).
+_capture_timeout_diagnostics() {
+  local test_pid="$1" test_id="$2" test_dir="$3"
+  local kids
+  kids=$(_descendant_pids "$test_pid")
+
+  echo ""
+  echo "----- TIMEOUT DIAGNOSTICS: $test_id (test pid $test_pid) -----"
+
+  echo "--- hung test process tree ---"
+  # shellcheck disable=SC2086
+  ps -ww -o pid,ppid,etime,command -p "$test_pid" $kids 2>/dev/null | head -40 || true
+
+  echo "--- all mcpc CLI / bridge processes ---"
+  ps -axww -o pid,etime,command 2>/dev/null \
+    | grep -E "dist/cli/index|dist/bridge/index|mcpc-bridge" | grep -v grep | head -30 || true
+
+  # Native stack of each hung descendant. macOS `sample` needs no privileges for
+  # own-user processes and pinpoints the exact syscall/frame the process is stuck on.
+  if command -v sample >/dev/null 2>&1; then
+    for pid in $kids; do
+      echo "--- sample pid=$pid ---"
+      sample "$pid" 1 2>/dev/null | sed -n '1,60p' || true
+    done
+  fi
+
+  # Per-test bridge logs. framework.sh prints the home dir in the test header
+  # ("# Home dir: <path> (<mode>)"), so recover it from the test's own output.
+  local home
+  home=$(grep -m1 '^# Home dir:' "$test_dir/output.log" 2>/dev/null \
+    | sed -e 's/^# Home dir: //' -e 's/ ([a-z]*)$//')
+  echo "--- bridge logs in: ${home:-?}/logs ---"
+  if [[ -n "$home" && -d "$home/logs" ]]; then
+    for f in "$home"/logs/bridge-*.log; do
+      [[ -f "$f" ]] || continue
+      echo "### $(basename "$f")"
+      tail -60 "$f" 2>/dev/null || true
+    done
+  fi
+  echo "----- END DIAGNOSTICS -----"
+}
+
 # Function to run a single test (with a per-test timeout watchdog)
 run_test() {
   local test_path="$1"
@@ -294,6 +349,11 @@ run_test() {
     # Detached bridge processes are reaped by the end-of-run cleanup.
     if kill -0 "$test_pid" 2>/dev/null; then
       : > "$timeout_marker"
+      # Capture the hung process tree's state while it's still alive. Written to a
+      # side file (not output.log) to avoid racing the test's own final writes;
+      # run_test appends it after the kill.
+      _capture_timeout_diagnostics "$test_pid" "$test_id" "$test_dir" \
+        > "$test_dir/.timeout_diag" 2>&1 || true
       pkill -P "$test_pid" 2>/dev/null || true
       kill -9 "$test_pid" 2>/dev/null || true
     fi
@@ -316,8 +376,9 @@ run_test() {
     {
       echo ""
       echo "TIMEOUT: test '$test_id' exceeded ${PER_TEST_TIMEOUT}s limit (killed by run.sh watchdog)"
+      [[ -f "$test_dir/.timeout_diag" ]] && cat "$test_dir/.timeout_diag"
     } >> "$test_dir/output.log"
-    rm -f "$timeout_marker"
+    rm -f "$timeout_marker" "$test_dir/.timeout_diag"
     result=137
   fi
 
@@ -383,7 +444,7 @@ elif _is_windows; then
   wait
 else
   # Parallel execution via xargs (Unix)
-  export -f run_test test_name
+  export -f run_test test_name _capture_timeout_diagnostics _descendant_pids
   printf '%s\n' "${TESTS[@]}" | xargs -P "$PARALLEL" -I {} bash -c 'run_test "$@"' _ {}
 fi
 

--- a/test/e2e/suites/basic/insecure.test.sh
+++ b/test/e2e/suites/basic/insecure.test.sh
@@ -22,26 +22,43 @@ run_mcpc "$SESSION_FAIL" tools-list
 assert_failure
 test_pass
 
-# Test: connection with --insecure flag succeeds
-test_case "connect with --insecure succeeds and tools-list works"
-SESSION=$(session_name "insecure-flag")
-run_mcpc connect "$TEST_HTTPS_SERVER_URL" "$SESSION" --header "X-Test: true" --insecure
-assert_success
-_SESSIONS_CREATED+=("$SESSION")
-test_pass
+# --insecure relies on undici's TLS-bypass dispatcher, which Bun's fetch ignores.
+# Since the bridge runs under the same runtime as the CLI, the behaviour differs:
+# under Node the flag works; under Bun mcpc rejects it loudly (rather than silently
+# failing to skip verification).
+RUNTIME="${E2E_RUNTIME:-node}"
 
-# Test: MCP operations work through insecure session
-test_case "tools-list works over insecure session"
-run_xmcpc "$SESSION" tools-list
-assert_success
-assert_contains "$STDOUT" "echo"
-test_pass
+if [ "$RUNTIME" = "bun" ]; then
+  # Test: --insecure is rejected with a clear error under Bun
+  test_case "bun: connect --insecure fails with a clear error"
+  SESSION=$(session_name "insecure-bun")
+  _SESSIONS_CREATED+=("$SESSION") # register for cleanup in case connect left a record
+  run_mcpc connect "$TEST_HTTPS_SERVER_URL" "$SESSION" --header "X-Test: true" --insecure
+  assert_failure
+  assert_contains "$STDERR" "not supported under the Bun runtime"
+  test_pass
+else
+  # Test: connection with --insecure flag succeeds (Node)
+  test_case "connect with --insecure succeeds and tools-list works"
+  SESSION=$(session_name "insecure-flag")
+  run_mcpc connect "$TEST_HTTPS_SERVER_URL" "$SESSION" --header "X-Test: true" --insecure
+  assert_success
+  _SESSIONS_CREATED+=("$SESSION")
+  test_pass
 
-# Test: tool call works
-test_case "tools-call works over insecure session"
-run_mcpc "$SESSION" tools-call echo message:=hello
-assert_success
-assert_contains "$STDOUT" "hello"
-test_pass
+  # Test: MCP operations work through insecure session
+  test_case "tools-list works over insecure session"
+  run_xmcpc "$SESSION" tools-list
+  assert_success
+  assert_contains "$STDOUT" "echo"
+  test_pass
+
+  # Test: tool call works
+  test_case "tools-call works over insecure session"
+  run_mcpc "$SESSION" tools-call echo message:=hello
+  assert_success
+  assert_contains "$STDOUT" "hello"
+  test_pass
+fi
 
 test_done

--- a/test/e2e/suites/basic/insecure.test.sh
+++ b/test/e2e/suites/basic/insecure.test.sh
@@ -22,43 +22,26 @@ run_mcpc "$SESSION_FAIL" tools-list
 assert_failure
 test_pass
 
-# --insecure relies on undici's TLS-bypass dispatcher, which Bun's fetch ignores.
-# Since the bridge runs under the same runtime as the CLI, the behaviour differs:
-# under Node the flag works; under Bun mcpc rejects it loudly (rather than silently
-# failing to skip verification).
-RUNTIME="${E2E_RUNTIME:-node}"
+# Test: connection with --insecure flag succeeds
+test_case "connect with --insecure succeeds and tools-list works"
+SESSION=$(session_name "insecure-flag")
+run_mcpc connect "$TEST_HTTPS_SERVER_URL" "$SESSION" --header "X-Test: true" --insecure
+assert_success
+_SESSIONS_CREATED+=("$SESSION")
+test_pass
 
-if [ "$RUNTIME" = "bun" ]; then
-  # Test: --insecure is rejected with a clear error under Bun
-  test_case "bun: connect --insecure fails with a clear error"
-  SESSION=$(session_name "insecure-bun")
-  _SESSIONS_CREATED+=("$SESSION") # register for cleanup in case connect left a record
-  run_mcpc connect "$TEST_HTTPS_SERVER_URL" "$SESSION" --header "X-Test: true" --insecure
-  assert_failure
-  assert_contains "$STDERR" "not supported under the Bun runtime"
-  test_pass
-else
-  # Test: connection with --insecure flag succeeds (Node)
-  test_case "connect with --insecure succeeds and tools-list works"
-  SESSION=$(session_name "insecure-flag")
-  run_mcpc connect "$TEST_HTTPS_SERVER_URL" "$SESSION" --header "X-Test: true" --insecure
-  assert_success
-  _SESSIONS_CREATED+=("$SESSION")
-  test_pass
+# Test: MCP operations work through insecure session
+test_case "tools-list works over insecure session"
+run_xmcpc "$SESSION" tools-list
+assert_success
+assert_contains "$STDOUT" "echo"
+test_pass
 
-  # Test: MCP operations work through insecure session
-  test_case "tools-list works over insecure session"
-  run_xmcpc "$SESSION" tools-list
-  assert_success
-  assert_contains "$STDOUT" "echo"
-  test_pass
-
-  # Test: tool call works
-  test_case "tools-call works over insecure session"
-  run_mcpc "$SESSION" tools-call echo message:=hello
-  assert_success
-  assert_contains "$STDOUT" "hello"
-  test_pass
-fi
+# Test: tool call works
+test_case "tools-call works over insecure session"
+run_mcpc "$SESSION" tools-call echo message:=hello
+assert_success
+assert_contains "$STDOUT" "hello"
+test_pass
 
 test_done

--- a/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
+++ b/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
@@ -54,9 +54,13 @@ tmp_file="$TEST_TMP/sessions.json.$$"
 # (headers are loaded from the keychain, not sessions.json, on restart).
 # Use a native path for require() — on Windows Node treats a leading "/" as the
 # current drive root, so "/d/a/.../keychain.js" resolves to "D:\d\a\..." (wrong).
+#
+# Seed via the SAME runtime the CLI uses ($E2E_RUNTIME), not a hardcoded "node":
+# macOS keychain ACLs are per-binary, so an item written by one binary and read
+# back by another triggers a blocking Security access prompt (hangs headless CI).
 NATIVE_PROJECT_ROOT="$(to_native_path "$PROJECT_ROOT")"
 NATIVE_MCPC_HOME="$(to_native_path "$MCPC_HOME_DIR")"
-node -e "
+"${E2E_RUNTIME:-node}" -e "
   process.env.MCPC_HOME_DIR = '$NATIVE_MCPC_HOME';
   const { storeKeychainSessionHeaders } = require('$NATIVE_PROJECT_ROOT/dist/lib/auth/keychain.js');
   storeKeychainSessionHeaders('$SESSION', {


### PR DESCRIPTION
Completes #265 (which added only the per-test timeout watchdog): fixes the macOS+Bun E2E hang. Root cause, pinned via the watchdog's `sample` backtrace: a Bun CLI spawned the bridge under a hardcoded `node`, so the Node bridge did a cross-binary macOS Keychain read that blocks on a Security prompt in headless CI.

- Run the bridge under the CLI's runtime (`process.execPath`) — one keychain identity; a Bun user no longer needs Node installed.
- Deliver the proxy bearer token to the bridge over IPC, so the bridge's only keychain access is the OAuth-refresh path (#55).
- `--insecure` works under both runtimes (Bun via `NODE_TLS_REJECT_UNAUTHORIZED=0` on the bridge, since Bun ignores undici's TLS-bypass).
- The timeout watchdog now dumps the process tree, a native `sample` backtrace, and the bridge log.
- Seed `unauthorized-auto-detect`'s keychain via the test's own runtime.

Green on macOS + Linux E2E (Bun & Node), unit, build, lint.

Refs #248, #265

https://claude.ai/code/session_01417BuEkifr5jSSx6R2MYCB