### PR TITLE
Add login --callback-host flag and required client_id in hosted CIMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The hosted OAuth Client ID Metadata Document now includes the required `client_id` property, so authorization servers that validate CIMD documents per spec no longer reject `mcpc login` with the default client identity (#271).
 - Sessions no longer hang on macOS under the Bun runtime (e.g. when connecting with `--proxy-bearer-token`, or auto-reconnecting a crashed session). The bridge now runs under the same runtime as the CLI, so OS-keychain items the CLI stored are read back under the same application identity; previously a Bun CLI paired with a Node bridge produced a cross-binary keychain read, which macOS gates with an access prompt that blocks in non-interactive contexts. A Bun user also no longer needs Node installed for the bridge to start.
 
 ## [0.3.1] - 2026-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `mcpc login --callback-host <host>` to set the host used in the OAuth callback redirect URI: `127.0.0.1` (default) or `localhost`, for servers whose pre-registered OAuth client only accepts the `localhost` form. The callback server itself still binds only to the loopback IP (#269).
+
 ### Removed
 
 - The interactive `shell` command (`mcpc shell @<session>` and `mcpc @<session> shell`), deprecated in 0.3.1, has been removed. Run individual `mcpc @<session> <command>` invocations instead. Server log messages (`notifications/message`), previously shown only in the shell, are now written to the bridge log — view them with `mcpc @<session> logs`.

--- a/README.md
+++ b/README.md
@@ -479,6 +479,10 @@ mcpc login mcp.apify.com
 # Pre-registered OAuth client (public or confidential) — skips CIMD.
 mcpc login mcp.example.com --client-id <id> [--client-secret <secret>]
 
+# Pre-registered client whose redirect URI was registered with localhost
+# instead of 127.0.0.1 (e.g. http://localhost:3118/callback).
+mcpc login mcp.example.com --client-id <id> --callback-host localhost --callback-port 3118
+
 # Custom CIMD: override the default with your own hosted document.
 mcpc login mcp.example.com --client-metadata-url https://example.com/my-client.json
 

--- a/client-metadata.json
+++ b/client-metadata.json
@@ -1,4 +1,5 @@
 {
+  "client_id": "https://apify.github.io/mcpc/client-metadata.json",
   "client_name": "mcpc",
   "client_uri": "https://github.com/apify/mcpc",
   "logo_uri": "https://apify.github.io/mcpc/client-logo.svg",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -28,6 +28,7 @@ export async function login(
     clientSecret?: string;
     clientMetadataUrl?: string | false;
     callbackPort?: number;
+    callbackHost?: string;
   }
 ): Promise<void> {
   try {
@@ -63,6 +64,20 @@ export async function login(
       resolvedClientMetadataUrl = DEFAULT_CLIENT_METADATA_URL;
     }
 
+    // The hosted CIMD registers only 127.0.0.1 redirect URIs, so a CIMD-capable
+    // server would reject the localhost form with a redirect_uri mismatch.
+    if (
+      options.callbackHost === 'localhost' &&
+      resolvedClientMetadataUrl === DEFAULT_CLIENT_METADATA_URL
+    ) {
+      throw new Error(
+        '--callback-host localhost cannot be used with the default hosted CIMD, which only ' +
+          'registers 127.0.0.1 redirect URIs. Use --client-id (pre-registered client), ' +
+          '--client-metadata-url (custom CIMD listing localhost redirect URIs), or ' +
+          '--no-client-metadata-url (Dynamic Client Registration)'
+      );
+    }
+
     if (options.outputMode === 'human') {
       console.log(formatInfo(`Starting OAuth authentication for ${normalizedUrl}`));
       console.log(formatInfo(`Profile: ${theme.magenta(profileName)}`));
@@ -88,7 +103,8 @@ export async function login(
       profileName,
       options.scope,
       clientCredentials,
-      options.callbackPort
+      options.callbackPort,
+      options.callbackHost
     );
 
     if (options.outputMode === 'human') {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import * as tasks from './commands/tasks.js';
 import * as grepCmd from './commands/grep.js';
 import { handleX402Command } from './commands/x402.js';
 import { clean } from './commands/clean.js';
+import { MCPC_OAUTH_CALLBACK_HOSTS, MCPC_OAUTH_CALLBACK_PORTS } from '../lib/auth/oauth-utils.js';
 import type { OutputMode, X402SchemePreference } from '../lib/index.js';
 import { X402_SCHEME_PREFERENCES } from '../lib/index.js';
 import {
@@ -643,13 +644,23 @@ ${jsonHelp(
       'HTTPS URL of an OAuth CIMD (default: https://apify.github.io/mcpc/client-metadata.json)'
     )
     .option('--no-client-metadata-url', 'Disable CIMD; force DCR on CIMD-capable servers')
-    .option('--callback-port <port>', 'Loopback port for OAuth callback (default: 13316–13325)')
+    .option(
+      '--callback-port <port>',
+      `Loopback port for OAuth callback (default: first free of ${MCPC_OAUTH_CALLBACK_PORTS.join(', ')})`
+    )
+    .option(
+      '--callback-host <host>',
+      'Host in the OAuth callback redirect URI: 127.0.0.1 (default) or localhost'
+    )
     .addHelpText(
       'after',
       `
 ${chalk.bold('OAuth client registration approaches:')}
 
   1. Pre-registration: --client-id (and optionally --client-secret).
+     If the client's registered redirect URI uses localhost instead of
+     127.0.0.1 (e.g. http://localhost:3118/callback), add
+     --callback-host localhost --callback-port 3118 to match it.
   2. Client ID Metadata Documents (CIMD): used by default. mcpc ships with a
      hosted CIMD at https://apify.github.io/mcpc/client-metadata.json
      which identifies all mcpc installs as the same client. Override with
@@ -680,6 +691,13 @@ ${jsonHelp('Interactive prompts are written to stderr, stdout contains a clean J
         }
         callbackPort = parsed;
       }
+      if (opts.callbackHost && !MCPC_OAUTH_CALLBACK_HOSTS.includes(opts.callbackHost as string)) {
+        throw new ClientError(
+          `Invalid --callback-host value: "${opts.callbackHost as string}". ` +
+            `Must be one of: ${MCPC_OAUTH_CALLBACK_HOSTS.join(', ')} ` +
+            '(loopback only — a non-loopback host would send the OAuth callback off this machine).'
+        );
+      }
       await auth.login(server, {
         profile: opts.profile,
         scope: opts.scope,
@@ -687,6 +705,7 @@ ${jsonHelp('Interactive prompts are written to stderr, stdout contains a clean J
         clientSecret: opts.clientSecret,
         clientMetadataUrl: opts.clientMetadataUrl,
         ...(callbackPort !== undefined ? { callbackPort } : {}),
+        ...(opts.callbackHost ? { callbackHost: opts.callbackHost as string } : {}),
         ...getOptionsFromCommand(command),
       });
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -691,12 +691,19 @@ ${jsonHelp('Interactive prompts are written to stderr, stdout contains a clean J
         }
         callbackPort = parsed;
       }
-      if (opts.callbackHost && !MCPC_OAUTH_CALLBACK_HOSTS.includes(opts.callbackHost as string)) {
-        throw new ClientError(
-          `Invalid --callback-host value: "${opts.callbackHost as string}". ` +
-            `Must be one of: ${MCPC_OAUTH_CALLBACK_HOSTS.join(', ')} ` +
-            '(loopback only — a non-loopback host would send the OAuth callback off this machine).'
-        );
+      let callbackHost: string | undefined;
+      if (opts.callbackHost) {
+        // URI hosts are case-insensitive (RFC 3986 §3.2.2), but redirect_uri
+        // matching at the authorization server is an exact string comparison,
+        // so normalize to lowercase rather than passing the casing through.
+        callbackHost = (opts.callbackHost as string).toLowerCase();
+        if (!MCPC_OAUTH_CALLBACK_HOSTS.includes(callbackHost)) {
+          throw new ClientError(
+            `Invalid --callback-host value: "${opts.callbackHost as string}". ` +
+              `Must be one of: ${MCPC_OAUTH_CALLBACK_HOSTS.join(', ')} ` +
+              '(loopback only — a non-loopback host would send the OAuth callback off this machine).'
+          );
+        }
       }
       await auth.login(server, {
         profile: opts.profile,
@@ -705,7 +712,7 @@ ${jsonHelp('Interactive prompts are written to stderr, stdout contains a clean J
         clientSecret: opts.clientSecret,
         clientMetadataUrl: opts.clientMetadataUrl,
         ...(callbackPort !== undefined ? { callbackPort } : {}),
-        ...(opts.callbackHost ? { callbackHost: opts.callbackHost as string } : {}),
+        ...(callbackHost ? { callbackHost } : {}),
         ...getOptionsFromCommand(command),
       });
     });

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -406,7 +406,8 @@ export async function performOAuthFlow(
   profileName: string,
   scope?: string,
   clientCredentials?: { clientId?: string; clientSecret?: string; clientMetadataUrl?: string },
-  callbackPort?: number
+  callbackPort?: number,
+  callbackHost?: string
 ): Promise<OAuthFlowResult> {
   logger.debug(`Starting OAuth flow for ${serverUrl} (profile: ${profileName})`);
 
@@ -426,7 +427,12 @@ export async function performOAuthFlow(
   // When --callback-port is set, use that exact port. Otherwise try the
   // fixed mcpc port list that matches the hosted CIMD's redirect_uris.
   const port = await findAvailablePort(callbackPort ? [callbackPort] : MCPC_OAUTH_CALLBACK_PORTS);
-  const redirectUrl = `http://127.0.0.1:${port}/callback`;
+  // --callback-host only changes the redirect URI string handed to the
+  // authorization server (some pre-registered clients accept only the
+  // `localhost` form). The callback server below always binds the loopback
+  // IP literal, never a hostname, per RFC 8252 §8.3 — browsers that resolve
+  // localhost to ::1 first fall back to 127.0.0.1 on connection refusal.
+  const redirectUrl = `http://${callbackHost || '127.0.0.1'}:${port}/callback`;
 
   logger.debug(`Using redirect URL: ${redirectUrl}`);
 

--- a/src/lib/auth/oauth-utils.ts
+++ b/src/lib/auth/oauth-utils.ts
@@ -22,6 +22,15 @@ export const DEFAULT_CLIENT_METADATA_URL = 'https://apify.github.io/mcpc/client-
 export const MCPC_OAUTH_CALLBACK_PORTS: readonly number[] = [13316, 31613, 16133] as const;
 
 /**
+ * Hosts accepted for the OAuth callback redirect URI (--callback-host).
+ * Loopback names only: a non-loopback host in the redirect URI would send
+ * the authorization code off-machine. The IP literal is the default per
+ * RFC 8252 §8.3; `localhost` exists for pre-registered clients whose
+ * redirect URI was registered with the hostname form (#269).
+ */
+export const MCPC_OAUTH_CALLBACK_HOSTS: readonly string[] = ['127.0.0.1', 'localhost'] as const;
+
+/**
  * OAuth token endpoint response (per OAuth 2.0 spec - uses snake_case)
  */
 export interface OAuthTokenResponse {

--- a/test/e2e/suites/basic/auth-errors.test.sh
+++ b/test/e2e/suites/basic/auth-errors.test.sh
@@ -194,35 +194,6 @@ assert_failure
 assert_contains "$STDERR" "--callback-port"
 test_pass
 
-test_case "login --help documents --callback-host"
-run_mcpc help login
-assert_success
-assert_contains "$STDOUT" "--callback-host"
-test_pass
-
-# Commander wraps long option descriptions, so assert each port separately.
-test_case "login --callback-port help text lists the actual default ports"
-run_mcpc help login
-assert_success
-assert_contains "$STDOUT" "13316"
-assert_contains "$STDOUT" "31613"
-assert_contains "$STDOUT" "16133"
-test_pass
-
-test_case "login --callback-host with non-loopback host is rejected"
-run_xmcpc login mcp.example.com --callback-host evil.example.com --no-client-metadata-url
-assert_failure
-assert_contains "$STDERR" "--callback-host"
-assert_contains "$STDERR" "loopback"
-test_pass
-
-test_case "login --callback-host localhost with default hosted CIMD is rejected"
-run_xmcpc login mcp.example.com --callback-host localhost
-assert_failure
-assert_contains "$STDERR" "127.0.0.1 redirect URIs"
-assert_contains "$STDERR" "--no-client-metadata-url"
-test_pass
-
 # =============================================================================
 # Test: Tier 2 - end-to-end callback port binding
 #

--- a/test/e2e/suites/basic/auth-errors.test.sh
+++ b/test/e2e/suites/basic/auth-errors.test.sh
@@ -194,6 +194,35 @@ assert_failure
 assert_contains "$STDERR" "--callback-port"
 test_pass
 
+test_case "login --help documents --callback-host"
+run_mcpc help login
+assert_success
+assert_contains "$STDOUT" "--callback-host"
+test_pass
+
+# Commander wraps long option descriptions, so assert each port separately.
+test_case "login --callback-port help text lists the actual default ports"
+run_mcpc help login
+assert_success
+assert_contains "$STDOUT" "13316"
+assert_contains "$STDOUT" "31613"
+assert_contains "$STDOUT" "16133"
+test_pass
+
+test_case "login --callback-host with non-loopback host is rejected"
+run_xmcpc login mcp.example.com --callback-host evil.example.com --no-client-metadata-url
+assert_failure
+assert_contains "$STDERR" "--callback-host"
+assert_contains "$STDERR" "loopback"
+test_pass
+
+test_case "login --callback-host localhost with default hosted CIMD is rejected"
+run_xmcpc login mcp.example.com --callback-host localhost
+assert_failure
+assert_contains "$STDERR" "127.0.0.1 redirect URIs"
+assert_contains "$STDERR" "--no-client-metadata-url"
+test_pass
+
 # =============================================================================
 # Test: Tier 2 - end-to-end callback port binding
 #

--- a/test/e2e/suites/basic/login-flags.test.sh
+++ b/test/e2e/suites/basic/login-flags.test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Test: login --callback-host and --callback-port flag validation
+#
+# These tests exercise CLI-side validation only (no network, no test server),
+# so they live in their own file rather than basic/auth-errors to keep that
+# suite within its per-test time budget.
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "basic/login-flags"
+
+# Commander wraps long option descriptions, so assert each port separately.
+test_case "login --help documents --callback-host and the actual default ports"
+run_mcpc help login
+assert_success
+assert_contains "$STDOUT" "--callback-host"
+assert_contains "$STDOUT" "13316"
+assert_contains "$STDOUT" "31613"
+assert_contains "$STDOUT" "16133"
+test_pass
+
+test_case "login --callback-host with non-loopback host is rejected"
+run_xmcpc login mcp.example.com --callback-host evil.example.com --no-client-metadata-url
+assert_failure
+assert_contains "$STDERR" "--callback-host"
+assert_contains "$STDERR" "loopback"
+test_pass
+
+test_case "login --callback-host localhost with default hosted CIMD is rejected"
+run_xmcpc login mcp.example.com --callback-host localhost
+assert_failure
+assert_contains "$STDERR" "127.0.0.1 redirect URIs"
+assert_contains "$STDERR" "--no-client-metadata-url"
+test_pass
+
+# Host comparison is case-insensitive (RFC 3986): LOCALHOST normalizes to
+# localhost, proven by it hitting the same default-CIMD guard.
+test_case "login --callback-host LOCALHOST is normalized to localhost"
+run_xmcpc login mcp.example.com --callback-host LOCALHOST
+assert_failure
+assert_contains "$STDERR" "127.0.0.1 redirect URIs"
+test_pass
+
+test_done

--- a/test/unit/lib/auth/oauth-utils.test.ts
+++ b/test/unit/lib/auth/oauth-utils.test.ts
@@ -6,6 +6,7 @@ import type { MockInstance } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import {
+  DEFAULT_CLIENT_METADATA_URL,
   discoverTokenEndpoint,
   MCPC_OAUTH_CALLBACK_PORTS,
 } from '../../../../src/lib/auth/oauth-utils.js';
@@ -158,7 +159,11 @@ describe('MCPC_OAUTH_CALLBACK_PORTS / client-metadata.json consistency', () => {
   const PROJECT_ROOT = resolve(__dirname, '../../../..');
   const metadata = JSON.parse(
     readFileSync(resolve(PROJECT_ROOT, 'client-metadata.json'), 'utf-8')
-  ) as { redirect_uris: string[] };
+  ) as { client_id: string; redirect_uris: string[] };
+
+  it('client_id matches the hosted document URL (required by CIMD spec)', () => {
+    expect(metadata.client_id).toBe(DEFAULT_CLIENT_METADATA_URL);
+  });
 
   it('every callback port has a matching loopback redirect_uri in client-metadata.json', () => {
     const expectedUris = MCPC_OAUTH_CALLBACK_PORTS.map(


### PR DESCRIPTION
`mcpc login` gets a `--callback-host` flag (`127.0.0.1` default, or `localhost`) so logins work against servers whose pre-registered OAuth client only accepts the `http://localhost:<port>/callback` redirect URI form. Also adds the `client_id` property required by the CIMD spec to the hosted client metadata document, which spec-compliant authorization servers otherwise reject.

- `--callback-host` is restricted to loopback values; the callback server still binds only the `127.0.0.1` IP literal (RFC 8252 §8.3)
- `--callback-host localhost` with the default hosted CIMD fails fast with guidance — the hosted document intentionally registers only `127.0.0.1` redirect URIs
- Fixed stale `--callback-port` help text (claimed range 13316–13325; the actual default is three fixed ports, now derived from `MCPC_OAUTH_CALLBACK_PORTS`)
- E2E coverage for the new validation paths; hosted `client_id` pinned in unit tests

Fixes #271
Fixes #269

https://claude.ai/code/session_01DfrRBieZsA9zumF4UV6XdT